### PR TITLE
Rename tab layout resources to snake_case

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -857,4 +857,7 @@
       </list>
     </option>
   </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/build/classes" />
+  </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.viewpager2)
+    implementation(libs.androidx.fragment.ktx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/papa/fr/football/MainActivity.kt
+++ b/app/src/main/java/com/papa/fr/football/MainActivity.kt
@@ -5,20 +5,37 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.papa.fr.football.common.matches.MatchesTabLayoutView
 import com.papa.fr.football.databinding.ActivityMainBinding
+import com.papa.fr.football.matches.MatchesListFragment
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityMainBinding.inflate(layoutInflater)
-
         enableEdgeToEdge()
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+
+        binding.matchesTabs.setupWith(
+            fragmentActivity = this,
+            tabs = listOf(
+                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_future)) {
+                    MatchesListFragment.newInstance(getString(R.string.matches_tab_future))
+                },
+                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_live)) {
+                    MatchesListFragment.newInstance(getString(R.string.matches_tab_live))
+                },
+                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_past)) {
+                    MatchesListFragment.newInstance(getString(R.string.matches_tab_past))
+                }
+            )
+        )
     }
 }

--- a/app/src/main/java/com/papa/fr/football/common/matches/MatchesTabLayoutView.kt
+++ b/app/src/main/java/com/papa/fr/football/common/matches/MatchesTabLayoutView.kt
@@ -1,0 +1,136 @@
+package com.papa.fr.football.common.matches
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayoutMediator
+import com.papa.fr.football.R
+import com.papa.fr.football.databinding.ItemMatchesTabBinding
+import com.papa.fr.football.databinding.ViewMatchesTabLayoutBinding
+
+class MatchesTabLayoutView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val binding = ViewMatchesTabLayoutBinding.inflate(LayoutInflater.from(context), this, true)
+    private var mediator: TabLayoutMediator? = null
+    private var pageChangeCallback: ViewPager2.OnPageChangeCallback? = null
+
+    init {
+        val typedArray = context.obtainStyledAttributes(attrs, R.styleable.MatchesTabLayoutView, defStyleAttr, 0)
+        val titleText = typedArray.getString(R.styleable.MatchesTabLayoutView_titleText)
+            ?: context.getString(R.string.matches_title)
+        binding.tvMatchesLabel.text = titleText
+        typedArray.recycle()
+        configureTabLayout()
+    }
+
+    private fun configureTabLayout() {
+        binding.tabLayout.apply {
+            tabMode = TabLayout.MODE_FIXED
+            tabGravity = TabLayout.GRAVITY_FILL
+            setSelectedTabIndicator(null)
+            tabRippleColor = null
+        }
+    }
+
+    fun setTitle(title: CharSequence) {
+        binding.tvMatchesLabel.text = title
+    }
+
+    fun setupWith(
+        fragmentActivity: FragmentActivity,
+        tabs: List<TabItem>,
+        defaultTabIndex: Int = 0
+    ) {
+        require(tabs.isNotEmpty()) { "Tabs list cannot be empty." }
+
+        binding.viewPager.adapter = MatchesPagerAdapter(fragmentActivity, tabs)
+
+        mediator?.detach()
+        mediator = TabLayoutMediator(binding.tabLayout, binding.viewPager) { tab, position ->
+            tab.customView = createTabView(tabs[position].title)
+        }.also { it.attach() }
+
+        binding.tabLayout.clearOnTabSelectedListeners()
+        binding.tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                updateTabSelection(tab.position)
+            }
+
+            override fun onTabUnselected(tab: TabLayout.Tab) {
+                updateTabSelection(binding.tabLayout.selectedTabPosition)
+            }
+
+            override fun onTabReselected(tab: TabLayout.Tab) = Unit
+        })
+
+        pageChangeCallback?.let { binding.viewPager.unregisterOnPageChangeCallback(it) }
+        pageChangeCallback = object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                updateTabSelection(position)
+            }
+        }.also { binding.viewPager.registerOnPageChangeCallback(it) }
+
+        val startIndex = defaultTabIndex.coerceIn(0, tabs.lastIndex)
+        binding.viewPager.setCurrentItem(startIndex, false)
+        binding.tabLayout.post { updateTabSelection(startIndex) }
+    }
+
+    private fun createTabView(title: String) =
+        ItemMatchesTabBinding.inflate(LayoutInflater.from(context), binding.tabLayout, false).apply {
+            tvTabTitle.text = title
+        }.root
+
+    private fun updateTabSelection(selectedPosition: Int) {
+        for (index in 0 until binding.tabLayout.tabCount) {
+            val tab = binding.tabLayout.getTabAt(index) ?: continue
+            val tabView = tab.customView ?: continue
+            val tabBinding = ItemMatchesTabBinding.bind(tabView)
+            val isSelected = index == selectedPosition
+            val backgroundRes = if (isSelected) {
+                R.drawable.bg_matches_tab_selected
+            } else {
+                R.drawable.bg_matches_tab_unselected
+            }
+            val textColorRes = if (isSelected) {
+                R.color.matches_tab_selected_text
+            } else {
+                R.color.matches_tab_unselected_text
+            }
+            tabBinding.tabRoot.background = ContextCompat.getDrawable(context, backgroundRes)
+            tabBinding.tvTabTitle.setTextColor(ContextCompat.getColor(context, textColorRes))
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        mediator?.detach()
+        mediator = null
+        pageChangeCallback?.let { binding.viewPager.unregisterOnPageChangeCallback(it) }
+        pageChangeCallback = null
+    }
+
+    data class TabItem(
+        val title: String,
+        val fragmentProvider: () -> Fragment
+    )
+
+    private class MatchesPagerAdapter(
+        fragmentActivity: FragmentActivity,
+        private val items: List<TabItem>
+    ) : FragmentStateAdapter(fragmentActivity) {
+        override fun getItemCount(): Int = items.size
+
+        override fun createFragment(position: Int): Fragment = items[position].fragmentProvider()
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/common/matches/MatchesTabLayoutView.kt
+++ b/app/src/main/java/com/papa/fr/football/common/matches/MatchesTabLayoutView.kt
@@ -14,6 +14,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.papa.fr.football.R
 import com.papa.fr.football.databinding.ItemMatchesTabBinding
 import com.papa.fr.football.databinding.ViewMatchesTabLayoutBinding
+import androidx.core.content.withStyledAttributes
 
 class MatchesTabLayoutView @JvmOverloads constructor(
     context: Context,
@@ -26,11 +27,11 @@ class MatchesTabLayoutView @JvmOverloads constructor(
     private var pageChangeCallback: ViewPager2.OnPageChangeCallback? = null
 
     init {
-        val typedArray = context.obtainStyledAttributes(attrs, R.styleable.MatchesTabLayoutView, defStyleAttr, 0)
-        val titleText = typedArray.getString(R.styleable.MatchesTabLayoutView_titleText)
-            ?: context.getString(R.string.matches_title)
-        binding.tvMatchesLabel.text = titleText
-        typedArray.recycle()
+        context.withStyledAttributes(attrs, R.styleable.MatchesTabLayoutView, defStyleAttr, 0) {
+            val titleText = getString(R.styleable.MatchesTabLayoutView_titleText)
+                ?: context.getString(R.string.matches_title)
+            binding.tvMatchesLabel.text = titleText
+        }
         configureTabLayout()
     }
 
@@ -105,7 +106,7 @@ class MatchesTabLayoutView @JvmOverloads constructor(
             val textColorRes = if (isSelected) {
                 R.color.matches_tab_selected_text
             } else {
-                R.color.matches_tab_unselected_text
+                R.color.white
             }
             tabBinding.tabRoot.background = ContextCompat.getDrawable(context, backgroundRes)
             tabBinding.tvTabTitle.setTextColor(ContextCompat.getColor(context, textColorRes))

--- a/app/src/main/java/com/papa/fr/football/matches/MatchesListFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/matches/MatchesListFragment.kt
@@ -1,0 +1,47 @@
+package com.papa.fr.football.matches
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import com.papa.fr.football.R
+import com.papa.fr.football.databinding.FragmentMatchesListBinding
+
+class MatchesListFragment : Fragment() {
+
+    private var _binding: FragmentMatchesListBinding? = null
+    private val binding: FragmentMatchesListBinding
+        get() = requireNotNull(_binding)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentMatchesListBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val tabLabel = requireArguments().getString(ARG_LABEL).orEmpty()
+        binding.tvPlaceholder.text = getString(R.string.matches_placeholder_format, tabLabel)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        private const val ARG_LABEL = "arg_label"
+
+        fun newInstance(label: String): MatchesListFragment {
+            return MatchesListFragment().apply {
+                arguments = bundleOf(ARG_LABEL to label)
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/bg_matches_tab_group.xml
+++ b/app/src/main/res/drawable/bg_matches_tab_group.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/matches_tab_group_background" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_matches_tab_group.xml
+++ b/app/src/main/res/drawable/bg_matches_tab_group.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/matches_tab_group_background" />
-    <corners android:radius="16dp" />
+    <corners android:radius="4dp" />
 </shape>

--- a/app/src/main/res/drawable/bg_matches_tab_selected.xml
+++ b/app/src/main/res/drawable/bg_matches_tab_selected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/matches_tab_selected_background" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_matches_tab_unselected.xml
+++ b/app/src/main/res/drawable/bg_matches_tab_unselected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/transparent" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/tab_background.xml
+++ b/app/src/main/res/drawable/tab_background.xml
@@ -1,0 +1,13 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/matches_tab_selected_background" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -78,4 +78,15 @@
         app:layout_constraintBottom_toBottomOf="@id/dd_season"
         app:layout_constraintTop_toTopOf="@id/dd_season" />
 
+    <com.papa.fr.football.common.matches.MatchesTabLayoutView
+        android:id="@+id/matches_tabs"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="24dp"
+        app:titleText="@string/matches_title"
+        app:layout_constraintTop_toBottomOf="@id/dd_season"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintEnd_toEndOf="@id/gl_end"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_matches_list.xml
+++ b/app/src/main/res/layout/fragment_matches_list.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/tv_placeholder"
+        style="@style/AlexandriaRegular.12sp.white"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="This is the Future matches screen." />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_matches_list.xml
+++ b/app/src/main/res/layout/fragment_matches_list.xml
@@ -2,8 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:padding="24dp">
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/tv_placeholder"
@@ -11,5 +10,4 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         tools:text="This is the Future matches screen." />
-
 </FrameLayout>

--- a/app/src/main/res/layout/item_league_dropdown.xml
+++ b/app/src/main/res/layout/item_league_dropdown.xml
@@ -14,7 +14,7 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/til"
         style="@style/Widget.Material3.TextInputLayout.FilledBox.ExposedDropdownMenu"
-        android:layout_width="wra"
+        android:layout_width="0dp"
         android:layout_height="36dp"
         android:layout_marginTop="4dp"
         android:textColorHint="@color/white"

--- a/app/src/main/res/layout/item_matches_tab.xml
+++ b/app/src/main/res/layout/item_matches_tab.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tab_root"
+    android:layout_width="wrap_content"
+    android:layout_height="36dp"
+    android:layout_gravity="center"
+    android:background="@drawable/bg_matches_tab_unselected"
+    android:paddingStart="20dp"
+    android:paddingEnd="20dp"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp">
+
+    <TextView
+        android:id="@+id/tv_tab_title"
+        style="@style/AlexandriaBold.12sp.matchesTab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        tools:text="Future" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/item_matches_tab.xml
+++ b/app/src/main/res/layout/item_matches_tab.xml
@@ -1,22 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/tab_root"
-    android:layout_width="wrap_content"
-    android:layout_height="36dp"
-    android:layout_gravity="center"
-    android:background="@drawable/bg_matches_tab_unselected"
-    android:paddingStart="20dp"
-    android:paddingEnd="20dp"
-    android:paddingTop="10dp"
-    android:paddingBottom="10dp">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/bg_matches_tab_unselected">
 
     <TextView
         android:id="@+id/tv_tab_title"
         style="@style/AlexandriaBold.12sp.matchesTab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:gravity="center"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:text="Future" />
 
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_matches_tab_layout.xml
+++ b/app/src/main/res/layout/view_matches_tab_layout.xml
@@ -13,35 +13,25 @@
         android:layout_height="wrap_content"
         tools:text="Matches" />
 
-    <LinearLayout
-        android:id="@+id/tab_container"
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tab_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
         android:background="@drawable/bg_matches_tab_group"
-        android:gravity="center"
-        android:padding="4dp">
-
-        <com.google.android.material.tabs.TabLayout
-            android:id="@+id/tab_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@android:color/transparent"
-            android:padding="0dp"
-            android:tabStripEnabled="false"
-            app:tabIndicator="@null"
-            app:tabIndicatorColor="@android:color/transparent"
-            app:tabIndicatorHeight="0dp"
-            app:tabMode="fixed"
-            app:tabRippleColor="@android:color/transparent" />
-    </LinearLayout>
+        android:padding="0dp"
+        android:tabStripEnabled="false"
+        app:tabBackground="@drawable/tab_background"
+        app:tabIndicator="@null"
+        app:tabIndicatorColor="@android:color/transparent"
+        app:tabIndicatorHeight="0dp"
+        app:tabMode="fixed"
+        app:tabRippleColor="@android:color/transparent" />
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:layout_marginBottom="16dp"
-        tools:layout_height="320dp" />
+        android:layout_marginBottom="16dp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/view_matches_tab_layout.xml
+++ b/app/src/main/res/layout/view_matches_tab_layout.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tv_matches_label"
+        style="@style/AlexandriaBold.14sp.white"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="Matches" />
+
+    <LinearLayout
+        android:id="@+id/tab_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/bg_matches_tab_group"
+        android:gravity="center"
+        android:padding="4dp">
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:padding="0dp"
+            android:tabStripEnabled="false"
+            app:tabIndicator="@null"
+            app:tabIndicatorColor="@android:color/transparent"
+            app:tabIndicatorHeight="0dp"
+            app:tabMode="fixed"
+            app:tabRippleColor="@android:color/transparent" />
+    </LinearLayout>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/view_pager"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        tools:layout_height="320dp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/attributes.xml
+++ b/app/src/main/res/values/attributes.xml
@@ -4,4 +4,8 @@
         <attr name="label" format="string" />
         <attr name="is_show_start_icon" format="boolean" />
     </declare-styleable>
+
+    <declare-styleable name="MatchesTabLayoutView">
+        <attr name="titleText" format="string" />
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,8 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="electric_lime">#066A73</color>
+    <color name="matches_tab_group_background">#111C2C</color>
+    <color name="matches_tab_selected_background">#7AF8F4</color>
+    <color name="matches_tab_selected_text">#050F1D</color>
+    <color name="matches_tab_unselected_text">#B1C1D1</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,8 @@
 <resources>
     <string name="app_name">Papa football</string>
+    <string name="matches_title">Matches</string>
+    <string name="matches_tab_future">Future</string>
+    <string name="matches_tab_live">Live</string>
+    <string name="matches_tab_past">Past</string>
+    <string name="matches_placeholder_format">This is the %1$s matches screen.</string>
 </resources>

--- a/app/src/main/res/values/typeface.xml
+++ b/app/src/main/res/values/typeface.xml
@@ -32,4 +32,9 @@
     <style name="AlexandriaBold.14sp.white" parent="AlexandriaBold.white">
         <item name="android:textSize">14sp</item>
     </style>
+
+    <style name="AlexandriaBold.12sp.matchesTab" parent="AlexandriaBold">
+        <item name="android:textColor">@color/matches_tab_unselected_text</item>
+        <item name="android:textSize">12sp</item>
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ appcompat = "1.7.1"
 material = "1.10.0"
 activity = "1.11.0"
 constraintlayout = "2.2.1"
+viewpager2 = "1.1.0"
+fragmentKtx = "1.8.5"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -19,6 +21,8 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragmentKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- rename newly added tab layout view IDs to snake_case across layout resources to follow project conventions
- keep binding usage untouched so the custom MatchesTabLayoutView continues to operate as before

## Testing
- `./gradlew lint` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf5b7b58c832d9a3dacd67d12475a