### PR TITLE
Refine schedule season dropdown

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -47,6 +48,16 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.viewpager2)
     implementation(libs.androidx.fragment.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.android)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.client.logging)
+    implementation(libs.koin.android)
+    implementation(libs.koin.androidx.viewmodel)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,9 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {
@@ -57,7 +60,6 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.client.logging)
     implementation(libs.koin.android)
-    implementation(libs.koin.androidx.viewmodel)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:name=".FootballApp"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".FootballApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/papa/fr/football/FootballApp.kt
+++ b/app/src/main/java/com/papa/fr/football/FootballApp.kt
@@ -1,0 +1,23 @@
+package com.papa.fr.football
+
+import android.app.Application
+import com.papa.fr.football.di.dataModule
+import com.papa.fr.football.di.domainModule
+import com.papa.fr.football.di.networkModule
+import com.papa.fr.football.di.presentationModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.logger.Level
+import org.koin.core.context.startKoin
+
+class FootballApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        startKoin {
+            androidLogger(if (BuildConfig.DEBUG) Level.ERROR else Level.NONE)
+            androidContext(this@FootballApp)
+            modules(listOf(networkModule, dataModule, domainModule, presentationModule))
+        }
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/MainActivity.kt
+++ b/app/src/main/java/com/papa/fr/football/MainActivity.kt
@@ -6,19 +6,38 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import com.papa.fr.football.common.matches.MatchesTabLayoutView
 import com.papa.fr.football.databinding.ActivityMainBinding
-import com.papa.fr.football.matches.MatchesListFragment
-import com.papa.fr.football.matches.MatchesTabType
+import com.papa.fr.football.presentation.navigation.BottomNavPlaceholderFragment
+import com.papa.fr.football.presentation.schedule.ScheduleFragment
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
+    private var selectedItemId: Int = R.id.menu_schedule
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        selectedItemId = savedInstanceState?.getInt(STATE_SELECTED_ITEM) ?: R.id.menu_schedule
+
+        setupWindowInsets()
+        setupBottomNav(binding.bottomNavigation)
+
+        if (savedInstanceState == null) {
+            binding.bottomNavigation.selectedItemId = selectedItemId
+        } else {
+            navigateTo(selectedItemId)
+            binding.bottomNavigation.selectedItemId = selectedItemId
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(STATE_SELECTED_ITEM, selectedItemId)
+    }
+
+    private fun setupWindowInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, 0)
@@ -29,35 +48,49 @@ class MainActivity : AppCompatActivity() {
             v.setPadding(v.paddingLeft, v.paddingTop, v.paddingRight, systemBars.bottom)
             insets
         }
-
-        setupMatchesTabs()
-        setupBottomNav(binding.bottomNavigation)
-    }
-
-    private fun setupMatchesTabs() {
-        binding.matchesTabs.setupWith(
-            fragmentActivity = this,
-            tabs = listOf(
-                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_future)) {
-                    MatchesListFragment.newInstance(MatchesTabType.FUTURE)
-                },
-                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_live)) {
-                    MatchesListFragment.newInstance(MatchesTabType.LIVE)
-                },
-                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_past)) {
-                    MatchesListFragment.newInstance(MatchesTabType.PAST)
-                }
-            )
-        )
     }
 
     private fun setupBottomNav(bottomNav: BottomNavigationView) {
-//        bottomNav.setOnItemSelectedListener { item ->
-//            when (item.itemId) {
-//                R.id.menu_schedule -> true
-//                else -> false
-//            }
-//        }
-        bottomNav.selectedItemId = R.id.menu_schedule
+        bottomNav.setOnItemSelectedListener { item ->
+            val handled = navigateTo(item.itemId)
+            if (handled) {
+                selectedItemId = item.itemId
+            }
+            handled
+        }
+        bottomNav.setOnItemReselectedListener { /* no-op */ }
+    }
+
+    private fun navigateTo(itemId: Int): Boolean {
+        val tag = itemId.toString()
+        val fragmentManager = supportFragmentManager
+        val transaction = fragmentManager.beginTransaction()
+
+        fragmentManager.fragments
+            .filter { it.id == R.id.fragment_container }
+            .forEach { transaction.hide(it) }
+
+        var fragment = fragmentManager.findFragmentByTag(tag)
+        if (fragment == null) {
+            fragment = when (itemId) {
+                R.id.menu_schedule -> ScheduleFragment()
+                R.id.menu_highlights -> BottomNavPlaceholderFragment.newInstance(getString(R.string.bottom_nav_highlights))
+                R.id.menu_teams -> BottomNavPlaceholderFragment.newInstance(getString(R.string.bottom_nav_teams))
+                R.id.menu_standings -> BottomNavPlaceholderFragment.newInstance(getString(R.string.bottom_nav_standings))
+                R.id.menu_settings -> BottomNavPlaceholderFragment.newInstance(getString(R.string.bottom_nav_settings))
+                else -> return false
+            }
+            transaction.add(R.id.fragment_container, fragment, tag)
+        } else {
+            transaction.show(fragment)
+        }
+
+        transaction.setReorderingAllowed(true)
+        transaction.commit()
+        return true
+    }
+
+    companion object {
+        private const val STATE_SELECTED_ITEM = "state_selected_item"
     }
 }

--- a/app/src/main/java/com/papa/fr/football/common/dropdown/LeagueDropdownView.kt
+++ b/app/src/main/java/com/papa/fr/football/common/dropdown/LeagueDropdownView.kt
@@ -28,7 +28,8 @@ class LeagueDropdownView @JvmOverloads constructor(
         attrs?.let {
             context.withStyledAttributes(it, R.styleable.LeagueDropdownView) {
                 binding.tvTitle.text = getString(R.styleable.LeagueDropdownView_label)
-                binding.til.isStartIconVisible = getBoolean(R.styleable.LeagueDropdownView_is_show_start_icon, false)
+                binding.til.isStartIconVisible =
+                    getBoolean(R.styleable.LeagueDropdownView_is_show_start_icon, false)
             }
         }
 
@@ -62,12 +63,15 @@ class LeagueDropdownView @JvmOverloads constructor(
             previouslySelectedId != null -> {
                 leagues.firstOrNull { it.id == previouslySelectedId }?.let { setSelected(it) }
             }
+
             placeholderText != null -> {
                 binding.actv.setText(placeholderText, false)
             }
+
             items.isNotEmpty() -> {
                 setSelected(items.first())
             }
+
             else -> {
                 binding.actv.setText("", false)
             }
@@ -117,7 +121,6 @@ class LeagueDropdownView @JvmOverloads constructor(
         super.setEnabled(enabled)
         binding.til.isEnabled = enabled
         binding.actv.isEnabled = enabled
-        binding.vIndicator.alpha = if (enabled) 1f else 0.4f
     }
 
     /** Save/restore selection across rotations **/
@@ -139,6 +142,7 @@ class LeagueDropdownView @JvmOverloads constructor(
             id != null -> {
                 leagues.firstOrNull { it.id == id }?.let { setSelected(it) }
             }
+
             placeholderText != null -> {
                 binding.actv.setText(placeholderText, false)
             }

--- a/app/src/main/java/com/papa/fr/football/common/dropdown/LeagueDropdownView.kt
+++ b/app/src/main/java/com/papa/fr/football/common/dropdown/LeagueDropdownView.kt
@@ -22,6 +22,7 @@ class LeagueDropdownView @JvmOverloads constructor(
 
     private var onChanged: ((LeagueItem) -> Unit)? = null
     private var leagues: List<LeagueItem> = emptyList()
+    private var placeholderText: String? = null
 
     init {
         attrs?.let {
@@ -34,12 +35,16 @@ class LeagueDropdownView @JvmOverloads constructor(
         binding.actv.setAdapter(adapter)
         binding.actv.setOnItemClickListener { _, _, position, _ ->
             val value = adapter.getItem(position) ?: return@setOnItemClickListener
+            setSelected(value)
             onChanged?.invoke(value)
         }
 
         // Optional: allow clicking the layout to open menu
         binding.til.setEndIconOnClickListener { binding.actv.showDropDown() }
         binding.actv.setOnClickListener { binding.actv.showDropDown() }
+
+        // Ensure initial enabled state cascades to children
+        setEnabled(isEnabled)
     }
 
 
@@ -48,12 +53,24 @@ class LeagueDropdownView @JvmOverloads constructor(
     }
 
     fun setData(items: List<LeagueItem>) {
+        val previouslySelectedId = getSelected()?.id
+
         leagues = items
         adapter.replaceAll(items)
-        // If current selection no longer exists, clear
-        val selected = getSelected()
-        if (selected == null && items.isNotEmpty()) {
-            setSelected(items.first())
+
+        when {
+            previouslySelectedId != null -> {
+                leagues.firstOrNull { it.id == previouslySelectedId }?.let { setSelected(it) }
+            }
+            placeholderText != null -> {
+                binding.actv.setText(placeholderText, false)
+            }
+            items.isNotEmpty() -> {
+                setSelected(items.first())
+            }
+            else -> {
+                binding.actv.setText("", false)
+            }
         }
     }
 
@@ -62,6 +79,7 @@ class LeagueDropdownView @JvmOverloads constructor(
             binding.actv.setText("", false)
             return
         }
+        placeholderText = null
         val index = leagues.indexOfFirst { it.id == target.id }
         if (index >= 0) {
             // setText(CharSequence, boolean) avoids filtering
@@ -69,13 +87,37 @@ class LeagueDropdownView @JvmOverloads constructor(
         }
     }
 
+    fun setPlaceholder(text: CharSequence?) {
+        placeholderText = text?.toString()
+        if (text == null) {
+            if (getSelected() == null) {
+                binding.actv.setText("", false)
+            }
+            return
+        }
+
+        if (getSelected() == null) {
+            binding.actv.setText(placeholderText, false)
+        }
+    }
+
     fun getSelected(): LeagueItem? {
         val name = binding.actv.text?.toString() ?: return null
+        if (placeholderText != null && name == placeholderText) {
+            return null
+        }
         return leagues.firstOrNull { it.name == name }
     }
 
     fun setOnChangedListener(listener: (LeagueItem) -> Unit) {
         onChanged = listener
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+        binding.til.isEnabled = enabled
+        binding.actv.isEnabled = enabled
+        binding.vIndicator.alpha = if (enabled) 1f else 0.4f
     }
 
     /** Save/restore selection across rotations **/
@@ -84,13 +126,22 @@ class LeagueDropdownView @JvmOverloads constructor(
         return Bundle().apply {
             putParcelable("super", superState)
             putString("selectedId", getSelected()?.id)
+            putString("placeholder", placeholderText)
         }
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
         val bundle = state as? Bundle
         super.onRestoreInstanceState(bundle?.getParcelable("super"))
-        val id = bundle?.getString("selectedId") ?: return
-        leagues.firstOrNull { it.id == id }?.let { setSelected(it) }
+        placeholderText = bundle?.getString("placeholder")
+        val id = bundle?.getString("selectedId")
+        when {
+            id != null -> {
+                leagues.firstOrNull { it.id == id }?.let { setSelected(it) }
+            }
+            placeholderText != null -> {
+                binding.actv.setText(placeholderText, false)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/papa/fr/football/common/dropdown/LeagueItem.kt
+++ b/app/src/main/java/com/papa/fr/football/common/dropdown/LeagueItem.kt
@@ -5,7 +5,7 @@ import androidx.annotation.DrawableRes
 data class LeagueItem(
     val id: String,
     val name: String,
-    @DrawableRes val iconRes: Int
+    @DrawableRes val iconRes: Int? = null
 ) {
     override fun toString(): String = name // used by accessibility & default adapters
 }

--- a/app/src/main/java/com/papa/fr/football/common/dropdown/LeagueItemAdapter.kt
+++ b/app/src/main/java/com/papa/fr/football/common/dropdown/LeagueItemAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
+import androidx.core.view.isVisible
 import com.papa.fr.football.databinding.ItemLeagueOptionBinding
 
 class LeagueItemAdapter(
@@ -33,7 +34,8 @@ class LeagueItemAdapter(
         }
 
         getItem(position)?.let { league ->
-            binding.icon.setImageResource(league.iconRes)
+            league.iconRes?.let { binding.icon.setImageResource(it) }
+            binding.icon.isVisible = league.iconRes != null
             binding.title.text = league.name
         }
 

--- a/app/src/main/java/com/papa/fr/football/data/mapper/SeasonMapper.kt
+++ b/app/src/main/java/com/papa/fr/football/data/mapper/SeasonMapper.kt
@@ -1,0 +1,13 @@
+package com.papa.fr.football.data.mapper
+
+import com.papa.fr.football.data.remote.dto.SeasonDto
+import com.papa.fr.football.domain.model.Season
+
+fun SeasonDto.toDomain(): Season {
+    return Season(
+        id = id,
+        name = name,
+        year = year,
+        editor = editor ?: false
+    )
+}

--- a/app/src/main/java/com/papa/fr/football/data/remote/SeasonApiService.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/SeasonApiService.kt
@@ -5,6 +5,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.http.encodedPath
 
 class SeasonApiService(private val httpClient: HttpClient) {
     suspend fun getUniqueTournamentSeasons(uniqueTournamentId: Int): UniqueTournamentSeasonsResponseDto {

--- a/app/src/main/java/com/papa/fr/football/data/remote/SeasonApiService.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/SeasonApiService.kt
@@ -1,0 +1,18 @@
+package com.papa.fr.football.data.remote
+
+import com.papa.fr.football.data.remote.dto.UniqueTournamentSeasonsResponseDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+
+class SeasonApiService(private val httpClient: HttpClient) {
+    suspend fun getUniqueTournamentSeasons(uniqueTournamentId: Int): UniqueTournamentSeasonsResponseDto {
+        return httpClient.get {
+            url {
+                encodedPath = "v1/unique-tournaments/seasons"
+            }
+            parameter("unique_tournament_id", uniqueTournamentId)
+        }.body()
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/data/remote/dto/SeasonDto.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/dto/SeasonDto.kt
@@ -1,0 +1,16 @@
+package com.papa.fr.football.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SeasonDto(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("name")
+    val name: String,
+    @SerialName("year")
+    val year: String? = null,
+    @SerialName("editor")
+    val editor: Boolean? = null
+)

--- a/app/src/main/java/com/papa/fr/football/data/remote/dto/UniqueTournamentSeasonsResponseDto.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/dto/UniqueTournamentSeasonsResponseDto.kt
@@ -1,0 +1,10 @@
+package com.papa.fr.football.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UniqueTournamentSeasonsResponseDto(
+    @SerialName("data")
+    val data: List<SeasonDto> = emptyList()
+)

--- a/app/src/main/java/com/papa/fr/football/data/repository/SeasonRepositoryImpl.kt
+++ b/app/src/main/java/com/papa/fr/football/data/repository/SeasonRepositoryImpl.kt
@@ -12,6 +12,7 @@ class SeasonRepositoryImpl(
         return apiService
             .getUniqueTournamentSeasons(uniqueTournamentId)
             .data
+            .take(5)
             .map { it.toDomain() }
     }
 }

--- a/app/src/main/java/com/papa/fr/football/data/repository/SeasonRepositoryImpl.kt
+++ b/app/src/main/java/com/papa/fr/football/data/repository/SeasonRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.papa.fr.football.data.repository
+
+import com.papa.fr.football.data.mapper.toDomain
+import com.papa.fr.football.data.remote.SeasonApiService
+import com.papa.fr.football.domain.model.Season
+import com.papa.fr.football.domain.repository.SeasonRepository
+
+class SeasonRepositoryImpl(
+    private val apiService: SeasonApiService
+) : SeasonRepository {
+    override suspend fun getUniqueTournamentSeasons(uniqueTournamentId: Int): List<Season> {
+        return apiService
+            .getUniqueTournamentSeasons(uniqueTournamentId)
+            .data
+            .map { it.toDomain() }
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/di/AppModules.kt
+++ b/app/src/main/java/com/papa/fr/football/di/AppModules.kt
@@ -1,0 +1,63 @@
+package com.papa.fr.football.di
+
+import com.papa.fr.football.data.remote.SeasonApiService
+import com.papa.fr.football.data.repository.SeasonRepositoryImpl
+import com.papa.fr.football.domain.repository.SeasonRepository
+import com.papa.fr.football.domain.usecase.GetSeasonsUseCase
+import com.papa.fr.football.presentation.seasons.SeasonsViewModel
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.header
+import io.ktor.http.URLProtocol
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+private const val BASE_HOST = "sofasport.p.rapidapi.com"
+private const val HEADER_API_KEY = "X-RapidAPI-Key"
+private const val HEADER_API_HOST = "X-RapidAPI-Host"
+private const val API_KEY_VALUE = "633787e55amsh33c9302558d5212p1064cdjsncbcd738c7c45"
+
+val networkModule = module {
+    single {
+        HttpClient(Android) {
+            install(DefaultRequest) {
+                url {
+                    protocol = URLProtocol.HTTPS
+                    host = BASE_HOST
+                }
+                header(HEADER_API_KEY, API_KEY_VALUE)
+                header(HEADER_API_HOST, BASE_HOST)
+            }
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        prettyPrint = false
+                    }
+                )
+            }
+            install(Logging) {
+                level = LogLevel.INFO
+            }
+        }
+    }
+}
+
+val dataModule = module {
+    single { SeasonApiService(get()) }
+    single<SeasonRepository> { SeasonRepositoryImpl(get()) }
+}
+
+val domainModule = module {
+    factory { GetSeasonsUseCase(get()) }
+}
+
+val presentationModule = module {
+    viewModel { SeasonsViewModel(get()) }
+}

--- a/app/src/main/java/com/papa/fr/football/domain/model/Season.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/model/Season.kt
@@ -1,0 +1,8 @@
+package com.papa.fr.football.domain.model
+
+data class Season(
+    val id: Int,
+    val name: String,
+    val year: String?,
+    val editor: Boolean
+)

--- a/app/src/main/java/com/papa/fr/football/domain/repository/SeasonRepository.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/repository/SeasonRepository.kt
@@ -1,0 +1,7 @@
+package com.papa.fr.football.domain.repository
+
+import com.papa.fr.football.domain.model.Season
+
+interface SeasonRepository {
+    suspend fun getUniqueTournamentSeasons(uniqueTournamentId: Int): List<Season>
+}

--- a/app/src/main/java/com/papa/fr/football/domain/usecase/GetSeasonsUseCase.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/usecase/GetSeasonsUseCase.kt
@@ -1,0 +1,10 @@
+package com.papa.fr.football.domain.usecase
+
+import com.papa.fr.football.domain.model.Season
+import com.papa.fr.football.domain.repository.SeasonRepository
+
+class GetSeasonsUseCase(private val seasonRepository: SeasonRepository) {
+    suspend operator fun invoke(uniqueTournamentId: Int): List<Season> {
+        return seasonRepository.getUniqueTournamentSeasons(uniqueTournamentId)
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/presentation/navigation/BottomNavPlaceholderFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/navigation/BottomNavPlaceholderFragment.kt
@@ -1,0 +1,47 @@
+package com.papa.fr.football.presentation.navigation
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import com.papa.fr.football.R
+import com.papa.fr.football.databinding.FragmentPlaceholderBinding
+
+private const val ARG_TITLE = "arg_title"
+
+class BottomNavPlaceholderFragment : Fragment() {
+
+    private var _binding: FragmentPlaceholderBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentPlaceholderBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val title = requireArguments().getString(ARG_TITLE).orEmpty()
+        val message = getString(R.string.bottom_nav_placeholder_message, title)
+        binding.tvPlaceholder.text = message
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        fun newInstance(title: String): BottomNavPlaceholderFragment {
+            return BottomNavPlaceholderFragment().apply {
+                arguments = bundleOf(ARG_TITLE to title)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/presentation/navigation/PlaceholderFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/navigation/PlaceholderFragment.kt
@@ -6,20 +6,18 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import com.papa.fr.football.R
 import com.papa.fr.football.databinding.FragmentPlaceholderBinding
 
-private const val ARG_TITLE = "arg_title"
-
-class BottomNavPlaceholderFragment : Fragment() {
+class PlaceholderFragment : Fragment() {
 
     private var _binding: FragmentPlaceholderBinding? = null
-    private val binding get() = _binding!!
+    private val binding: FragmentPlaceholderBinding
+        get() = requireNotNull(_binding)
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentPlaceholderBinding.inflate(inflater, container, false)
         return binding.root
@@ -27,8 +25,7 @@ class BottomNavPlaceholderFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val title = requireArguments().getString(ARG_TITLE).orEmpty()
-        val message = getString(R.string.bottom_nav_placeholder_message, title)
+        val message = requireArguments().getString(ARG_MESSAGE).orEmpty()
         binding.tvPlaceholder.text = message
     }
 
@@ -38,10 +35,14 @@ class BottomNavPlaceholderFragment : Fragment() {
     }
 
     companion object {
-        fun newInstance(title: String): BottomNavPlaceholderFragment {
-            return BottomNavPlaceholderFragment().apply {
-                arguments = bundleOf(ARG_TITLE to title)
+        private const val ARG_MESSAGE = "arg_message"
+
+        fun newInstance(message: String): PlaceholderFragment {
+            return PlaceholderFragment().apply {
+                arguments = bundleOf(ARG_MESSAGE to message)
             }
         }
+
+        fun tagFor(itemId: Int): String = "placeholder_$itemId"
     }
 }

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
@@ -114,4 +114,8 @@ class ScheduleFragment : Fragment() {
         super.onDestroyView()
         _binding = null
     }
+
+    companion object {
+        const val TAG = "ScheduleFragment"
+    }
 }

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
@@ -79,17 +79,13 @@ class ScheduleFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 seasonsViewModel.uiState.collect { state ->
-                    binding.ddSeason.isEnabled = !state.isLoading
-                    binding.btnSchedule.isEnabled = !state.isLoading
-
                     val seasonIds = state.seasons.map { it.id }
                     if (seasonIds != lastSeasonIds && state.seasons.isNotEmpty()) {
                         lastSeasonIds = seasonIds
                         val items = state.seasons.map { season ->
                             LeagueItem(
                                 id = season.id.toString(),
-                                name = season.name,
-                                iconRes = R.drawable.ic_nav_schedule
+                                name = season.year.orEmpty()
                             )
                         }
                         binding.ddSeason.setData(items)

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
@@ -1,0 +1,121 @@
+package com.papa.fr.football.presentation.schedule
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.snackbar.Snackbar
+import com.papa.fr.football.R
+import com.papa.fr.football.common.dropdown.LeagueItem
+import com.papa.fr.football.common.matches.MatchesTabLayoutView
+import com.papa.fr.football.databinding.FragmentScheduleBinding
+import com.papa.fr.football.matches.MatchesListFragment
+import com.papa.fr.football.matches.MatchesTabType
+import com.papa.fr.football.presentation.seasons.SeasonsViewModel
+import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import java.util.Calendar
+import java.util.Locale
+
+private const val DEFAULT_UNIQUE_TOURNAMENT_ID = 8
+
+class ScheduleFragment : Fragment() {
+
+    private var _binding: FragmentScheduleBinding? = null
+    private val binding get() = _binding!!
+
+    private val seasonsViewModel: SeasonsViewModel by viewModel()
+
+    private var lastSeasonIds: List<Int> = emptyList()
+    private var lastErrorMessage: String? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentScheduleBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupMatchesTabs()
+        observeSeasons()
+
+        binding.ddSeason.setPlaceholder(defaultSeasonLabel())
+
+        binding.btnSchedule.setOnClickListener {
+            seasonsViewModel.loadSeasons(DEFAULT_UNIQUE_TOURNAMENT_ID)
+        }
+
+        if (seasonsViewModel.uiState.value.seasons.isEmpty()) {
+            seasonsViewModel.loadSeasons(DEFAULT_UNIQUE_TOURNAMENT_ID)
+        }
+    }
+
+    private fun setupMatchesTabs() {
+        binding.matchesTabs.setupWith(
+            fragmentActivity = requireActivity(),
+            tabs = listOf(
+                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_future)) {
+                    MatchesListFragment.newInstance(MatchesTabType.FUTURE)
+                },
+                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_live)) {
+                    MatchesListFragment.newInstance(MatchesTabType.LIVE)
+                },
+                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_past)) {
+                    MatchesListFragment.newInstance(MatchesTabType.PAST)
+                }
+            )
+        )
+    }
+
+    private fun observeSeasons() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                seasonsViewModel.uiState.collect { state ->
+                    binding.ddSeason.isEnabled = !state.isLoading
+                    binding.btnSchedule.isEnabled = !state.isLoading
+
+                    val seasonIds = state.seasons.map { it.id }
+                    if (seasonIds != lastSeasonIds && state.seasons.isNotEmpty()) {
+                        lastSeasonIds = seasonIds
+                        val items = state.seasons.map { season ->
+                            LeagueItem(
+                                id = season.id.toString(),
+                                name = season.name,
+                                iconRes = R.drawable.ic_nav_schedule
+                            )
+                        }
+                        binding.ddSeason.setData(items)
+                    }
+
+                    val errorMessage = state.errorMessage?.ifBlank { getString(R.string.season_load_error) }
+                    if (errorMessage != null && errorMessage != lastErrorMessage) {
+                        lastErrorMessage = errorMessage
+                        Snackbar.make(binding.root, errorMessage, Snackbar.LENGTH_LONG).show()
+                    } else if (errorMessage == null) {
+                        lastErrorMessage = null
+                    }
+                }
+            }
+        }
+    }
+
+    private fun defaultSeasonLabel(): String {
+        val calendar = Calendar.getInstance()
+        val startYear = calendar.get(Calendar.YEAR) % 100
+        val endYear = (startYear + 1) % 100
+        return String.format(Locale.getDefault(), "%02d/%02d", startYear, endYear)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/presentation/seasons/SeasonsUiState.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/seasons/SeasonsUiState.kt
@@ -1,0 +1,9 @@
+package com.papa.fr.football.presentation.seasons
+
+import com.papa.fr.football.domain.model.Season
+
+data class SeasonsUiState(
+    val isLoading: Boolean = false,
+    val seasons: List<Season> = emptyList(),
+    val errorMessage: String? = null
+)

--- a/app/src/main/java/com/papa/fr/football/presentation/seasons/SeasonsViewModel.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/seasons/SeasonsViewModel.kt
@@ -1,0 +1,43 @@
+package com.papa.fr.football.presentation.seasons
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.papa.fr.football.domain.usecase.GetSeasonsUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class SeasonsViewModel(
+    private val getSeasonsUseCase: GetSeasonsUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SeasonsUiState())
+    val uiState: StateFlow<SeasonsUiState> = _uiState.asStateFlow()
+
+    fun loadSeasons(uniqueTournamentId: Int) {
+        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+
+        viewModelScope.launch {
+            runCatching { getSeasonsUseCase(uniqueTournamentId) }
+                .onSuccess { seasons ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            seasons = seasons,
+                            errorMessage = null
+                        )
+                    }
+                }
+                .onFailure { throwable ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = throwable.message.orEmpty()
+                        )
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/presentation/seasons/SeasonsViewModel.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/seasons/SeasonsViewModel.kt
@@ -1,5 +1,6 @@
 package com.papa.fr.football.presentation.seasons
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.papa.fr.football.domain.usecase.GetSeasonsUseCase
@@ -22,6 +23,7 @@ class SeasonsViewModel(
         viewModelScope.launch {
             runCatching { getSeasonsUseCase(uniqueTournamentId) }
                 .onSuccess { seasons ->
+                    Log.d("IQBAL-TEST", "loadSeasons: $seasons")
                     _uiState.update {
                         it.copy(
                             isLoading = false,

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,6 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
-        android:name="androidx.fragment.app.FragmentContainerView"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@id/bottom_navigation"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,86 +8,16 @@
     android:background="@drawable/bg_main"
     tools:context=".MainActivity">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/gl_top"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_begin="35dp"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/gl_start"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_begin="16dp"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/gl_end"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_end="16dp"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_schedule"
-        style="@style/Widget.MaterialComponents.Button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="@style/AlexandriaBold.12sp.white"
-        android:textColor="@color/white"
-        app:cornerRadius="4dp"
-        app:icon="@drawable/ic_refresh"
-        app:iconGravity="textStart"
-        app:iconPadding="12dp"
-        app:layout_constraintStart_toEndOf="@id/gl_start"
-        app:layout_constraintTop_toBottomOf="@id/gl_top"
-        tools:text="Updated 01.09.2025 09:00" />
-
-    <ImageView
-        android:id="@+id/ib_profile"
-        android:layout_width="36dp"
-        android:layout_height="0dp"
-        android:src="@drawable/ic_profile"
-        app:layout_constraintBottom_toBottomOf="@id/btn_schedule"
-        app:layout_constraintEnd_toEndOf="@id/gl_end"
-        app:layout_constraintTop_toTopOf="@id/btn_schedule"
-        tools:ignore="contentDescription" />
-
-    <com.papa.fr.football.common.dropdown.LeagueDropdownView
-        android:id="@+id/dd_season"
-        android:layout_width="110dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="16dp"
-        app:label="Season"
-        app:layout_constraintStart_toStartOf="@id/gl_start"
-        app:layout_constraintTop_toBottomOf="@id/btn_schedule" />
-
-    <com.papa.fr.football.common.dropdown.LeagueDropdownView
-        android:id="@+id/dd_league"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        app:label="League"
-        app:is_show_start_icon="true"
-        app:layout_constraintBottom_toBottomOf="@id/dd_season"
-        app:layout_constraintEnd_toEndOf="@id/gl_end"
-        app:layout_constraintStart_toEndOf="@id/dd_season"
-        app:layout_constraintTop_toTopOf="@id/dd_season" />
-
-    <com.papa.fr.football.common.matches.MatchesTabLayoutView
-        android:id="@+id/matches_tabs"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
+        android:name="androidx.fragment.app.FragmentContainerView"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginTop="24dp"
-        app:titleText="@string/matches_title"
         app:layout_constraintBottom_toTopOf="@id/bottom_navigation"
-        app:layout_constraintEnd_toEndOf="@id/gl_end"
-        app:layout_constraintStart_toStartOf="@id/gl_start"
-        app:layout_constraintTop_toBottomOf="@id/dd_season" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:layout="@layout/fragment_schedule" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"

--- a/app/src/main/res/layout/fragment_placeholder.xml
+++ b/app/src/main/res/layout/fragment_placeholder.xml
@@ -7,7 +7,7 @@
 
     <TextView
         android:id="@+id/tv_placeholder"
-        style="@style/AlexandriaBold.16sp.white"
+        style="@style/AlexandriaBold.18sp.white"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"

--- a/app/src/main/res/layout/fragment_placeholder.xml
+++ b/app/src/main/res/layout/fragment_placeholder.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_placeholder"
+        style="@style/AlexandriaBold.16sp.white"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Placeholder" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_schedule.xml
+++ b/app/src/main/res/layout/fragment_schedule.xml
@@ -57,9 +57,8 @@
 
     <com.papa.fr.football.common.dropdown.LeagueDropdownView
         android:id="@+id/dd_season"
-        android:layout_width="wrap_content"
+        android:layout_width="120dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
         app:label="Season"
         app:layout_constraintStart_toStartOf="@id/gl_start"
         app:layout_constraintTop_toBottomOf="@id/btn_schedule" />

--- a/app/src/main/res/layout/fragment_schedule.xml
+++ b/app/src/main/res/layout/fragment_schedule.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.schedule.ScheduleFragment">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_top"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="35dp"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="16dp"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_end"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="16dp"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_schedule"
+        style="@style/Widget.MaterialComponents.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/AlexandriaBold.12sp.white"
+        android:textColor="@color/white"
+        app:cornerRadius="4dp"
+        app:icon="@drawable/ic_refresh"
+        app:iconGravity="textStart"
+        app:iconPadding="12dp"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/gl_top"
+        tools:text="Updated 01.09.2025 09:00" />
+
+    <ImageView
+        android:id="@+id/ib_profile"
+        android:layout_width="36dp"
+        android:layout_height="0dp"
+        android:src="@drawable/ic_profile"
+        app:layout_constraintBottom_toBottomOf="@id/btn_schedule"
+        app:layout_constraintEnd_toEndOf="@id/gl_end"
+        app:layout_constraintTop_toTopOf="@id/btn_schedule"
+        tools:ignore="contentDescription" />
+
+    <com.papa.fr.football.common.dropdown.LeagueDropdownView
+        android:id="@+id/dd_season"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:label="Season"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/btn_schedule" />
+
+    <com.papa.fr.football.common.dropdown.LeagueDropdownView
+        android:id="@+id/dd_league"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        app:is_show_start_icon="true"
+        app:label="League"
+        app:layout_constraintBottom_toBottomOf="@id/dd_season"
+        app:layout_constraintEnd_toEndOf="@id/gl_end"
+        app:layout_constraintStart_toEndOf="@id/dd_season"
+        app:layout_constraintTop_toTopOf="@id/dd_season" />
+
+    <com.papa.fr.football.common.matches.MatchesTabLayoutView
+        android:id="@+id/matches_tabs"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="24dp"
+        app:titleText="@string/matches_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/gl_end"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/dd_season" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_league_dropdown.xml
+++ b/app/src/main/res/layout/item_league_dropdown.xml
@@ -1,7 +1,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
     <TextView
@@ -14,15 +14,16 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/til"
         style="@style/Widget.Material3.TextInputLayout.FilledBox.ExposedDropdownMenu"
-        android:layout_width="0dp"
-        android:layout_height="36dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
+        android:minHeight="36dp"
         android:textColorHint="@color/white"
         app:boxBackgroundColor="@color/electric_lime"
         app:endIconDrawable="@drawable/ic_dropdown"
         app:endIconTint="@color/white"
         app:expandedHintEnabled="false"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constrainedWidth="true"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_title"
         app:startIconCheckable="false"
@@ -32,8 +33,9 @@
 
         <AutoCompleteTextView
             android:id="@+id/actv"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:minWidth="72dp"
             android:dropDownHeight="wrap_content"
             android:dropDownVerticalOffset="8dp"
             android:importantForAutofill="no"
@@ -42,4 +44,15 @@
             tools:ignore="labelFor" />
 
     </com.google.android.material.textfield.TextInputLayout>
+
+    <View
+        android:id="@+id/v_indicator"
+        android:layout_width="0dp"
+        android:layout_height="2dp"
+        android:layout_marginTop="2dp"
+        android:background="@color/season_dropdown_indicator"
+        app:layout_constraintEnd_toEndOf="@id/til"
+        app:layout_constraintStart_toStartOf="@id/til"
+        app:layout_constraintTop_toBottomOf="@id/til" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_league_dropdown.xml
+++ b/app/src/main/res/layout/item_league_dropdown.xml
@@ -1,7 +1,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <TextView
@@ -14,16 +14,18 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/til"
         style="@style/Widget.Material3.TextInputLayout.FilledBox.ExposedDropdownMenu"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
-        android:minHeight="36dp"
+        android:textAppearance="@style/AlexandriaBold.14sp.white"
         android:textColorHint="@color/white"
         app:boxBackgroundColor="@color/electric_lime"
+        app:boxStrokeColor="@android:color/transparent"
+        app:boxStrokeWidth="0dp"
+        app:boxStrokeWidthFocused="0dp"
         app:endIconDrawable="@drawable/ic_dropdown"
         app:endIconTint="@color/white"
         app:expandedHintEnabled="false"
-        app:layout_constrainedWidth="true"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_title"
         app:startIconCheckable="false"
@@ -33,26 +35,18 @@
 
         <AutoCompleteTextView
             android:id="@+id/actv"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:minWidth="72dp"
+            android:layout_gravity="center"
             android:dropDownHeight="wrap_content"
-            android:dropDownVerticalOffset="8dp"
+            android:dropDownVerticalOffset="0dp"
+            android:fontFamily="@font/alexandria_bold"
+            android:textAlignment="center"
             android:importantForAutofill="no"
             android:inputType="none"
-            android:textAppearance="@style/AlexandriaBold.14sp.white"
+            android:textColor="@color/white"
+            android:textSize="16sp"
             tools:ignore="labelFor" />
 
     </com.google.android.material.textfield.TextInputLayout>
-
-    <View
-        android:id="@+id/v_indicator"
-        android:layout_width="0dp"
-        android:layout_height="2dp"
-        android:layout_marginTop="2dp"
-        android:background="@color/season_dropdown_indicator"
-        app:layout_constraintEnd_toEndOf="@id/til"
-        app:layout_constraintStart_toStartOf="@id/til"
-        app:layout_constraintTop_toBottomOf="@id/til" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_league_option.xml
+++ b/app/src/main/res/layout/item_league_option.xml
@@ -1,23 +1,26 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="56dp"
-    android:gravity="center_vertical"
-    android:orientation="horizontal"
-    android:paddingStart="16dp"
-    android:paddingEnd="16dp">
+    android:layout_height="wrap_content"
+    android:background="@color/matches_card_background"
+    android:orientation="horizontal">
 
     <ImageView
         android:id="@+id/icon"
         android:layout_width="28dp"
         android:layout_height="28dp"
         android:contentDescription="@null"
-        android:scaleType="centerInside" />
+        android:scaleType="centerInside"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/title"
+        style="@style/AlexandriaBold.18sp.white"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_weight="1"
-        android:textAppearance="?attr/textAppearanceBodyLarge" />
-</LinearLayout>
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="25/26" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,6 +5,7 @@
     <color name="electric_lime">#066A73</color>
     <color name="matches_tab_group_background">#111C2C</color>
     <color name="cyan">#7AF8F4</color>
+    <color name="season_dropdown_indicator">#8A55FF</color>
     <color name="matches_tab_selected_text">#050F1D</color>
     <color name="matches_tab_unselected_text">#B1C1D1</color>
     <color name="matches_card_background">#122034</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,6 @@
     <string name="matches_tab_future_label">Future matches</string>
     <string name="matches_tab_live_label">Live matches</string>
     <string name="matches_tab_past_label">Past matches</string>
+    <string name="bottom_nav_placeholder_message">The %1$s screen is coming soon.</string>
+    <string name="season_load_error">Unable to load seasons. Please try again.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="matches_tab_past_label">Past matches</string>
     <string name="bottom_nav_placeholder_message">The %1$s screen is coming soon.</string>
     <string name="season_load_error">Unable to load seasons. Please try again.</string>
+    <string name="placeholder_coming_soon">Coming soon: %1$s</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,6 @@ ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serializatio
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
-koin-androidx-viewmodel = { group = "io.insert-koin", name = "koin-androidx-viewmodel", version.ref = "koin" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewModel" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,11 @@ activity = "1.11.0"
 constraintlayout = "2.2.1"
 viewpager2 = "1.1.0"
 fragmentKtx = "1.8.5"
+ktor = "3.0.1"
+kotlinxSerialization = "1.7.3"
+koin = "3.5.6"
+coroutines = "1.9.0"
+lifecycleViewModel = "2.8.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -23,8 +28,19 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
 androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragmentKtx" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
+koin-androidx-viewmodel = { group = "io.insert-koin", name = "koin-androidx-viewmodel", version.ref = "koin" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewModel" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- embed the main screen in a bottom-nav-driven fragment container with placeholders for non-schedule tabs
- add a ScheduleFragment that wires the seasons ViewModel into the season dropdown and reuses the existing matches tabs UI
- update resources for the new layouts and provide default messaging for placeholder tabs and season load failures
- trim the season dropdown to wrap its content, add the accent indicator, and seed it with a default season label that updates when users pick another season

## Testing
- ./gradlew lint --no-daemon --stacktrace *(fails: SDK location not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3ae82e30832dbd08ecb381c9a2b5