### PR TITLE
Implement bottom navigation-driven schedule fragment

### DIFF
--- a/app/src/main/java/com/papa/fr/football/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/schedule/ScheduleFragment.kt
@@ -1,0 +1,59 @@
+package com.papa.fr.football.schedule
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.papa.fr.football.R
+import com.papa.fr.football.common.matches.MatchesTabLayoutView
+import com.papa.fr.football.databinding.FragmentScheduleBinding
+import com.papa.fr.football.matches.MatchesListFragment
+import com.papa.fr.football.matches.MatchesTabType
+
+class ScheduleFragment : Fragment() {
+
+    private var _binding: FragmentScheduleBinding? = null
+    private val binding: FragmentScheduleBinding
+        get() = requireNotNull(_binding)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentScheduleBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupMatchesTabs()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setupMatchesTabs() {
+        binding.matchesTabs.setupWith(
+            fragmentActivity = requireActivity(),
+            tabs = listOf(
+                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_future)) {
+                    MatchesListFragment.newInstance(MatchesTabType.FUTURE)
+                },
+                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_live)) {
+                    MatchesListFragment.newInstance(MatchesTabType.LIVE)
+                },
+                MatchesTabLayoutView.TabItem(getString(R.string.matches_tab_past)) {
+                    MatchesListFragment.newInstance(MatchesTabType.PAST)
+                },
+            ),
+        )
+    }
+
+    companion object {
+        const val TAG = "ScheduleFragment"
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/ui/PlaceholderFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/ui/PlaceholderFragment.kt
@@ -1,0 +1,48 @@
+package com.papa.fr.football.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import com.papa.fr.football.databinding.FragmentPlaceholderBinding
+
+class PlaceholderFragment : Fragment() {
+
+    private var _binding: FragmentPlaceholderBinding? = null
+    private val binding: FragmentPlaceholderBinding
+        get() = requireNotNull(_binding)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentPlaceholderBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val message = requireArguments().getString(ARG_MESSAGE).orEmpty()
+        binding.tvPlaceholderMessage.text = message
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        private const val ARG_MESSAGE = "arg_message"
+
+        fun newInstance(message: String): PlaceholderFragment {
+            return PlaceholderFragment().apply {
+                arguments = bundleOf(ARG_MESSAGE to message)
+            }
+        }
+
+        fun tagFor(itemId: Int): String = "placeholder_$itemId"
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,86 +8,14 @@
     android:background="@drawable/bg_main"
     tools:context=".MainActivity">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/gl_top"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_begin="35dp"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/gl_start"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_begin="16dp"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/gl_end"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_end="16dp"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/btn_schedule"
-        style="@style/Widget.MaterialComponents.Button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="@style/AlexandriaBold.12sp.white"
-        android:textColor="@color/white"
-        app:cornerRadius="4dp"
-        app:icon="@drawable/ic_refresh"
-        app:iconGravity="textStart"
-        app:iconPadding="12dp"
-        app:layout_constraintStart_toEndOf="@id/gl_start"
-        app:layout_constraintTop_toBottomOf="@id/gl_top"
-        tools:text="Updated 01.09.2025 09:00" />
-
-    <ImageView
-        android:id="@+id/ib_profile"
-        android:layout_width="36dp"
-        android:layout_height="0dp"
-        android:src="@drawable/ic_profile"
-        app:layout_constraintBottom_toBottomOf="@id/btn_schedule"
-        app:layout_constraintEnd_toEndOf="@id/gl_end"
-        app:layout_constraintTop_toTopOf="@id/btn_schedule"
-        tools:ignore="contentDescription" />
-
-    <com.papa.fr.football.common.dropdown.LeagueDropdownView
-        android:id="@+id/dd_season"
-        android:layout_width="110dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="16dp"
-        app:label="Season"
-        app:layout_constraintStart_toStartOf="@id/gl_start"
-        app:layout_constraintTop_toBottomOf="@id/btn_schedule" />
-
-    <com.papa.fr.football.common.dropdown.LeagueDropdownView
-        android:id="@+id/dd_league"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        app:label="League"
-        app:is_show_start_icon="true"
-        app:layout_constraintBottom_toBottomOf="@id/dd_season"
-        app:layout_constraintEnd_toEndOf="@id/gl_end"
-        app:layout_constraintStart_toEndOf="@id/dd_season"
-        app:layout_constraintTop_toTopOf="@id/dd_season" />
-
-    <com.papa.fr.football.common.matches.MatchesTabLayoutView
-        android:id="@+id/matches_tabs"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginTop="24dp"
-        app:titleText="@string/matches_title"
         app:layout_constraintBottom_toTopOf="@id/bottom_navigation"
-        app:layout_constraintEnd_toEndOf="@id/gl_end"
-        app:layout_constraintStart_toStartOf="@id/gl_start"
-        app:layout_constraintTop_toBottomOf="@id/dd_season" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"

--- a/app/src/main/res/layout/fragment_placeholder.xml
+++ b/app/src/main/res/layout/fragment_placeholder.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    tools:context=".ui.PlaceholderFragment">
+
+    <TextView
+        android:id="@+id/tv_placeholder_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/alexandria_semibold"
+        android:padding="24dp"
+        android:textAlignment="center"
+        android:textColor="@color/white"
+        android:textSize="18sp"
+        tools:text="Coming soon" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_schedule.xml
+++ b/app/src/main/res/layout/fragment_schedule.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".schedule.ScheduleFragment">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_top"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="35dp"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="16dp"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_end"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="16dp"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_schedule"
+        style="@style/Widget.MaterialComponents.Button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/AlexandriaBold.12sp.white"
+        android:textColor="@color/white"
+        app:cornerRadius="4dp"
+        app:icon="@drawable/ic_refresh"
+        app:iconGravity="textStart"
+        app:iconPadding="12dp"
+        app:layout_constraintStart_toEndOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/gl_top"
+        tools:text="Updated 01.09.2025 09:00" />
+
+    <ImageView
+        android:id="@+id/ib_profile"
+        android:layout_width="36dp"
+        android:layout_height="0dp"
+        android:src="@drawable/ic_profile"
+        app:layout_constraintBottom_toBottomOf="@id/btn_schedule"
+        app:layout_constraintEnd_toEndOf="@id/gl_end"
+        app:layout_constraintTop_toTopOf="@id/btn_schedule"
+        tools:ignore="contentDescription" />
+
+    <com.papa.fr.football.common.dropdown.LeagueDropdownView
+        android:id="@+id/dd_season"
+        android:layout_width="110dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        app:label="Season"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/btn_schedule" />
+
+    <com.papa.fr.football.common.dropdown.LeagueDropdownView
+        android:id="@+id/dd_league"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        app:is_show_start_icon="true"
+        app:label="League"
+        app:layout_constraintBottom_toBottomOf="@id/dd_season"
+        app:layout_constraintEnd_toEndOf="@id/gl_end"
+        app:layout_constraintStart_toEndOf="@id/dd_season"
+        app:layout_constraintTop_toTopOf="@id/dd_season" />
+
+    <com.papa.fr.football.common.matches.MatchesTabLayoutView
+        android:id="@+id/matches_tabs"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/gl_end"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/dd_season"
+        app:titleText="@string/matches_title" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="bottom_nav_teams">Teams</string>
     <string name="bottom_nav_standings">Standings</string>
     <string name="bottom_nav_settings">Settings</string>
+    <string name="placeholder_coming_soon">Coming soon: %1$s</string>
     <string name="matches_tab_future_label">Future matches</string>
     <string name="matches_tab_live_label">Live matches</string>
     <string name="matches_tab_past_label">Past matches</string>


### PR DESCRIPTION
## Summary
- replace the activity layout with a fragment container above the bottom navigation bar
- add a dedicated `ScheduleFragment` that configures the matches tabs and associated layout
- wire the bottom navigation to fragment transactions with placeholder destinations for unfinished tabs

## Testing
- `./gradlew lint` *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc57298ad8832d99962d272b095629