### PR TITLE
Move league dropdown data to viewmodel

### DIFF
--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
@@ -46,43 +46,10 @@ class ScheduleFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         setupMatchesTabs()
         observeSeasons()
+        observeLeagues()
 
         binding.ddSeason.setPlaceholder(defaultSeasonLabel())
-        binding.ddLeague.setPlaceholder("La Liga")
-        binding.ddLeague.setData(
-            listOf(
-                LeagueItem(
-                    id = 8.toString(),
-                    name = "La Liga",
-                    iconRes = R.drawable.ic_laliga
-                ),
-                LeagueItem(
-                    id = 17.toString(),
-                    name = "Premier League",
-                    iconRes = R.drawable.ic_premier_league
-                ),
-                LeagueItem(
-                    id = 35.toString(),
-                    name = "Bundesliga",
-                    iconRes = R.drawable.ic_bundesliga
-                ),
-                LeagueItem(
-                    id = 34.toString(),
-                    name = "La Liga",
-                    iconRes = R.drawable.ic_ligue
-                ),
-                LeagueItem(
-                    id = 23.toString(),
-                    name = "Serie A",
-                    iconRes = R.drawable.ic_serie_a
-                ),
-                LeagueItem(
-                    id = 37.toString(),
-                    name = "Eredivise",
-                    iconRes = R.drawable.eredivisie
-                ),
-            )
-        )
+        binding.ddLeague.setPlaceholder(seasonsViewModel.defaultLeagueLabel())
 
         binding.btnSchedule.setOnClickListener {
             seasonsViewModel.loadSeasons(DEFAULT_UNIQUE_TOURNAMENT_ID)
@@ -133,6 +100,18 @@ class ScheduleFragment : Fragment() {
                         Snackbar.make(binding.root, errorMessage, Snackbar.LENGTH_LONG).show()
                     } else if (errorMessage == null) {
                         lastErrorMessage = null
+                    }
+                }
+            }
+        }
+    }
+
+    private fun observeLeagues() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                seasonsViewModel.leagueItems.collect { leagues ->
+                    if (leagues.isNotEmpty()) {
+                        binding.ddLeague.setData(leagues)
                     }
                 }
             }

--- a/app/src/main/java/com/papa/fr/football/presentation/seasons/SeasonsViewModel.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/seasons/SeasonsViewModel.kt
@@ -3,6 +3,8 @@ package com.papa.fr.football.presentation.seasons
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.papa.fr.football.R
+import com.papa.fr.football.common.dropdown.LeagueItem
 import com.papa.fr.football.domain.usecase.GetSeasonsUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +18,44 @@ class SeasonsViewModel(
 
     private val _uiState = MutableStateFlow(SeasonsUiState())
     val uiState: StateFlow<SeasonsUiState> = _uiState.asStateFlow()
+
+    private val _leagueItems = MutableStateFlow(
+        listOf(
+            LeagueItem(
+                id = 8.toString(),
+                name = "La Liga",
+                iconRes = R.drawable.ic_laliga
+            ),
+            LeagueItem(
+                id = 17.toString(),
+                name = "Premier League",
+                iconRes = R.drawable.ic_premier_league
+            ),
+            LeagueItem(
+                id = 35.toString(),
+                name = "Bundesliga",
+                iconRes = R.drawable.ic_bundesliga
+            ),
+            LeagueItem(
+                id = 34.toString(),
+                name = "La Liga",
+                iconRes = R.drawable.ic_ligue
+            ),
+            LeagueItem(
+                id = 23.toString(),
+                name = "Serie A",
+                iconRes = R.drawable.ic_serie_a
+            ),
+            LeagueItem(
+                id = 37.toString(),
+                name = "Eredivise",
+                iconRes = R.drawable.eredivisie
+            ),
+        )
+    )
+    val leagueItems: StateFlow<List<LeagueItem>> = _leagueItems.asStateFlow()
+
+    fun defaultLeagueLabel(): String = _leagueItems.value.firstOrNull()?.name.orEmpty()
 
     fun loadSeasons(uniqueTournamentId: Int) {
         _uiState.update { it.copy(isLoading = true, errorMessage = null) }


### PR DESCRIPTION
## Summary
- expose the league dropdown items from SeasonsViewModel instead of hardcoding them in the fragment
- add a helper for the default league placeholder and observe the league list from ScheduleFragment

## Testing
- ./gradlew :app:lint *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca436b730832d9ff94185a9f91ef8