### PR TITLE
Integrate season event fetching and team logos

### DIFF
--- a/app/src/main/java/com/papa/fr/football/common/itemteam/ItemListTeam.kt
+++ b/app/src/main/java/com/papa/fr/football/common/itemteam/ItemListTeam.kt
@@ -1,7 +1,9 @@
 package com.papa.fr.football.common.itemteam
 
 import android.content.Context
+import android.graphics.BitmapFactory
 import android.util.AttributeSet
+import android.util.Base64
 import android.view.LayoutInflater
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -37,6 +39,26 @@ class ItemListTeam @JvmOverloads constructor(
 
     fun setLogo(@DrawableRes logo: Int) {
         binding.ivLogo.setImageDrawable(ContextCompat.getDrawable(context, logo))
+    }
+
+    fun setLogoBase64(base64: String?) {
+        if (base64.isNullOrBlank()) {
+            binding.ivLogo.setImageDrawable(null)
+            return
+        }
+
+        val decodedBytes = runCatching { Base64.decode(base64, Base64.DEFAULT) }.getOrNull()
+        if (decodedBytes == null) {
+            binding.ivLogo.setImageDrawable(null)
+            return
+        }
+
+        val bitmap = BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.size)
+        if (bitmap != null) {
+            binding.ivLogo.setImageBitmap(bitmap)
+        } else {
+            binding.ivLogo.setImageDrawable(null)
+        }
     }
 
     fun setIndicatorActive(isActive: Boolean) {

--- a/app/src/main/java/com/papa/fr/football/data/mapper/EventMapper.kt
+++ b/app/src/main/java/com/papa/fr/football/data/mapper/EventMapper.kt
@@ -1,0 +1,23 @@
+package com.papa.fr.football.data.mapper
+
+import com.papa.fr.football.data.remote.dto.EventDto
+import com.papa.fr.football.domain.model.Match
+import com.papa.fr.football.domain.model.MatchTeam
+
+fun EventDto.toDomain(homeLogoBase64: String?, awayLogoBase64: String?): Match {
+    val safeStartTimestamp = startTimestamp ?: 0L
+    return Match(
+        id = id.toString(),
+        startTimestamp = safeStartTimestamp,
+        homeTeam = MatchTeam(
+            id = homeTeam?.id ?: -1,
+            name = homeTeam?.name.orEmpty(),
+            logoBase64 = homeLogoBase64.orEmpty(),
+        ),
+        awayTeam = MatchTeam(
+            id = awayTeam?.id ?: -1,
+            name = awayTeam?.name.orEmpty(),
+            logoBase64 = awayLogoBase64.orEmpty(),
+        ),
+    )
+}

--- a/app/src/main/java/com/papa/fr/football/data/remote/SeasonApiService.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/SeasonApiService.kt
@@ -1,5 +1,6 @@
 package com.papa.fr.football.data.remote
 
+import com.papa.fr.football.data.remote.dto.SeasonEventsResponseDto
 import com.papa.fr.football.data.remote.dto.UniqueTournamentSeasonsResponseDto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -14,6 +15,21 @@ class SeasonApiService(private val httpClient: HttpClient) {
                 encodedPath = "v1/unique-tournaments/seasons"
             }
             parameter("unique_tournament_id", uniqueTournamentId)
+        }.body()
+    }
+
+    suspend fun getSeasonEvents(
+        uniqueTournamentId: Int,
+        seasonId: Int,
+        page: Int = 1,
+        courseEvents: String = "next",
+    ): SeasonEventsResponseDto {
+        return httpClient.get {
+            url { encodedPath = "v1/seasons/events" }
+            parameter("unique_tournament_id", uniqueTournamentId)
+            parameter("seasons_id", seasonId)
+            parameter("page", page)
+            parameter("course_events", courseEvents)
         }.body()
     }
 }

--- a/app/src/main/java/com/papa/fr/football/data/remote/TeamApiService.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/TeamApiService.kt
@@ -1,0 +1,17 @@
+package com.papa.fr.football.data.remote
+
+import com.papa.fr.football.data.remote.dto.TeamLogoResponseDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.http.encodedPath
+
+class TeamApiService(private val httpClient: HttpClient) {
+    suspend fun getTeamLogo(teamId: Int): TeamLogoResponseDto {
+        return httpClient.get {
+            url { encodedPath = "v1/teams/logo" }
+            parameter("team_id", teamId)
+        }.body()
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/data/remote/TeamApiService.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/TeamApiService.kt
@@ -1,17 +1,28 @@
 package com.papa.fr.football.data.remote
 
-import com.papa.fr.football.data.remote.dto.TeamLogoResponseDto
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.statement.body
+import io.ktor.client.statement.contentType
 import io.ktor.http.encodedPath
+import io.ktor.http.ContentType
 
 class TeamApiService(private val httpClient: HttpClient) {
-    suspend fun getTeamLogo(teamId: Int): TeamLogoResponseDto {
-        return httpClient.get {
+    suspend fun getTeamLogo(teamId: Int): TeamLogoRaw {
+        val response = httpClient.get {
             url { encodedPath = "v1/teams/logo" }
             parameter("team_id", teamId)
-        }.body()
+        }
+
+        return TeamLogoRaw(
+            contentType = response.contentType(),
+            body = response.body(),
+        )
     }
 }
+
+data class TeamLogoRaw(
+    val contentType: ContentType?,
+    val body: ByteArray,
+)

--- a/app/src/main/java/com/papa/fr/football/data/remote/dto/SeasonEventsResponseDto.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/dto/SeasonEventsResponseDto.kt
@@ -1,0 +1,36 @@
+package com.papa.fr.football.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SeasonEventsResponseDto(
+    @SerialName("data")
+    val data: SeasonEventsDataDto = SeasonEventsDataDto(),
+)
+
+@Serializable
+data class SeasonEventsDataDto(
+    @SerialName("events")
+    val events: List<EventDto> = emptyList(),
+)
+
+@Serializable
+data class EventDto(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("homeTeam")
+    val homeTeam: EventTeamDto? = null,
+    @SerialName("awayTeam")
+    val awayTeam: EventTeamDto? = null,
+    @SerialName("startTimestamp")
+    val startTimestamp: Long? = null,
+)
+
+@Serializable
+data class EventTeamDto(
+    @SerialName("id")
+    val id: Int? = null,
+    @SerialName("name")
+    val name: String? = null,
+)

--- a/app/src/main/java/com/papa/fr/football/data/remote/dto/TeamLogoResponseDto.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/dto/TeamLogoResponseDto.kt
@@ -1,0 +1,10 @@
+package com.papa.fr.football.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TeamLogoResponseDto(
+    @SerialName("data")
+    val data: String? = null,
+)

--- a/app/src/main/java/com/papa/fr/football/data/repository/MatchRepositoryImpl.kt
+++ b/app/src/main/java/com/papa/fr/football/data/repository/MatchRepositoryImpl.kt
@@ -1,15 +1,24 @@
 package com.papa.fr.football.data.repository
 
+import android.util.Base64
 import com.papa.fr.football.data.mapper.toDomain
 import com.papa.fr.football.data.remote.SeasonApiService
 import com.papa.fr.football.data.remote.TeamApiService
+import com.papa.fr.football.data.remote.TeamLogoRaw
+import com.papa.fr.football.data.remote.dto.TeamLogoResponseDto
 import com.papa.fr.football.domain.model.Match
 import com.papa.fr.football.domain.repository.MatchRepository
+import io.ktor.http.ContentType
+import io.ktor.http.match
+import io.ktor.http.withoutParameters
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 class MatchRepositoryImpl(
     private val seasonApiService: SeasonApiService,
@@ -17,7 +26,9 @@ class MatchRepositoryImpl(
 ) : MatchRepository {
 
     private val teamLogoCache = ConcurrentHashMap<Int, String>()
-    private val logoSemaphore = Semaphore(LOGO_REQUEST_CONCURRENCY)
+    private val logoMutex = Mutex()
+    @Volatile
+    private var lastLogoRequestAt: Long = 0L
 
     override suspend fun getUpcomingMatches(uniqueTournamentId: Int, seasonId: Int): List<Match> =
         coroutineScope {
@@ -49,14 +60,25 @@ class MatchRepositoryImpl(
     private suspend fun fetchTeamLogo(teamId: Int): String {
         teamLogoCache[teamId]?.let { return it }
 
-        val sanitizedLogo = logoSemaphore.withPermit {
-            runCatching { teamApiService.getTeamLogo(teamId).data }
-                .map { it.sanitizeBase64() }
-                .getOrElse { "" }
-        }
+        val sanitizedLogo = logoMutex.withLock {
+            teamLogoCache[teamId]?.let { return it }
 
-        if (sanitizedLogo.isNotBlank()) {
-            teamLogoCache[teamId] = sanitizedLogo
+            val elapsed = System.currentTimeMillis() - lastLogoRequestAt
+            if (elapsed < LOGO_REQUEST_INTERVAL_MS) {
+                delay(LOGO_REQUEST_INTERVAL_MS - elapsed)
+            }
+
+            val sanitized = runCatching {
+                teamApiService.getTeamLogo(teamId).toSanitizedBase64()
+            }.getOrElse { "" }
+
+            lastLogoRequestAt = System.currentTimeMillis()
+
+            if (sanitized.isNotBlank()) {
+                teamLogoCache[teamId] = sanitized
+            }
+
+            sanitized
         }
 
         return sanitizedLogo
@@ -74,7 +96,50 @@ class MatchRepositoryImpl(
         return trimmed.trim()
     }
 
+    private fun TeamLogoRaw.toSanitizedBase64(): String {
+        val normalizedContentType = contentType?.withoutParameters()
+
+        if (normalizedContentType != null && normalizedContentType.match(ContentType.Image.Any)) {
+            return body.encodeToBase64()
+        }
+
+        val rawText = body.decodeToString().trim()
+        if (rawText.isEmpty()) return ""
+
+        if (normalizedContentType == ContentType.Application.Json || rawText.startsWith("{")) {
+            val base64FromJson = runCatching {
+                json.decodeFromString<TeamLogoResponseDto>(rawText).data
+            }.getOrNull()
+            base64FromJson?.sanitizeBase64()?.takeIf { it.isLikelyBase64() }?.let { return it }
+        }
+
+        val sanitized = rawText.sanitizeBase64()
+        if (sanitized.isLikelyBase64()) {
+            return sanitized
+        }
+
+        return body.encodeToBase64()
+    }
+
+    private fun ByteArray.encodeToBase64(): String {
+        if (isEmpty()) return ""
+        return Base64.encodeToString(this, Base64.NO_WRAP)
+    }
+
+    private fun String.isLikelyBase64(): Boolean {
+        if (isBlank() || length < MIN_BASE64_LENGTH) return false
+        val candidate = replace("\n", "").replace("\r", "")
+        if (candidate.any { !it.isBase64Char() }) return false
+        return true
+    }
+
+    private fun Char.isBase64Char(): Boolean {
+        return isLetterOrDigit() || this == '+' || this == '/' || this == '=' || this == '-' || this == '_'
+    }
+
     private companion object {
-        private const val LOGO_REQUEST_CONCURRENCY = 3
+        private const val LOGO_REQUEST_INTERVAL_MS = 650L
+        private const val MIN_BASE64_LENGTH = 32
+        private val json = Json { ignoreUnknownKeys = true }
     }
 }

--- a/app/src/main/java/com/papa/fr/football/data/repository/MatchRepositoryImpl.kt
+++ b/app/src/main/java/com/papa/fr/football/data/repository/MatchRepositoryImpl.kt
@@ -1,0 +1,58 @@
+package com.papa.fr.football.data.repository
+
+import com.papa.fr.football.data.mapper.toDomain
+import com.papa.fr.football.data.remote.SeasonApiService
+import com.papa.fr.football.data.remote.TeamApiService
+import com.papa.fr.football.domain.model.Match
+import com.papa.fr.football.domain.repository.MatchRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+class MatchRepositoryImpl(
+    private val seasonApiService: SeasonApiService,
+    private val teamApiService: TeamApiService,
+) : MatchRepository {
+
+    override suspend fun getUpcomingMatches(uniqueTournamentId: Int, seasonId: Int): List<Match> =
+        coroutineScope {
+            val events = seasonApiService
+                .getSeasonEvents(uniqueTournamentId, seasonId)
+                .data
+                .events
+
+            if (events.isEmpty()) {
+                return@coroutineScope emptyList()
+            }
+
+            val teamIds = events.flatMap { event ->
+                listOfNotNull(event.homeTeam?.id, event.awayTeam?.id)
+            }.toSet()
+
+            val logos = teamIds.associateWith { teamId ->
+                async {
+                    runCatching { teamApiService.getTeamLogo(teamId).data }
+                        .map { it.sanitizeBase64() }
+                        .getOrElse { "" }
+                }
+            }.mapValues { (_, deferred) -> deferred.await() }
+
+            events.map { event ->
+                event.toDomain(
+                    homeLogoBase64 = event.homeTeam?.id?.let { logos[it] },
+                    awayLogoBase64 = event.awayTeam?.id?.let { logos[it] },
+                )
+            }
+        }
+
+    private fun String?.sanitizeBase64(): String {
+        if (this.isNullOrBlank()) return ""
+        val delimiter = "base64,"
+        val index = indexOf(delimiter)
+        val trimmed = if (index >= 0) {
+            substring(index + delimiter.length)
+        } else {
+            this
+        }
+        return trimmed.trim()
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/di/AppModules.kt
+++ b/app/src/main/java/com/papa/fr/football/di/AppModules.kt
@@ -1,8 +1,12 @@
 package com.papa.fr.football.di
 
 import com.papa.fr.football.data.remote.SeasonApiService
+import com.papa.fr.football.data.remote.TeamApiService
+import com.papa.fr.football.data.repository.MatchRepositoryImpl
 import com.papa.fr.football.data.repository.SeasonRepositoryImpl
+import com.papa.fr.football.domain.repository.MatchRepository
 import com.papa.fr.football.domain.repository.SeasonRepository
+import com.papa.fr.football.domain.usecase.GetUpcomingMatchesUseCase
 import com.papa.fr.football.domain.usecase.GetSeasonsUseCase
 import com.papa.fr.football.presentation.schedule.ScheduleViewModel
 import io.ktor.client.HttpClient
@@ -51,13 +55,16 @@ val networkModule = module {
 
 val dataModule = module {
     single { SeasonApiService(get()) }
+    single { TeamApiService(get()) }
     single<SeasonRepository> { SeasonRepositoryImpl(get()) }
+    single<MatchRepository> { MatchRepositoryImpl(get(), get()) }
 }
 
 val domainModule = module {
     factory { GetSeasonsUseCase(get()) }
+    factory { GetUpcomingMatchesUseCase(get()) }
 }
 
 val presentationModule = module {
-    viewModel { ScheduleViewModel(get()) }
+    viewModel { ScheduleViewModel(get(), get()) }
 }

--- a/app/src/main/java/com/papa/fr/football/domain/model/Match.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/model/Match.kt
@@ -1,0 +1,20 @@
+package com.papa.fr.football.domain.model
+
+/**
+ * Domain representation of a scheduled match event.
+ */
+data class Match(
+    val id: String,
+    val startTimestamp: Long,
+    val homeTeam: MatchTeam,
+    val awayTeam: MatchTeam,
+)
+
+/**
+ * Lightweight model describing a team participating in a match.
+ */
+data class MatchTeam(
+    val id: Int,
+    val name: String,
+    val logoBase64: String,
+)

--- a/app/src/main/java/com/papa/fr/football/domain/repository/MatchRepository.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/repository/MatchRepository.kt
@@ -1,0 +1,7 @@
+package com.papa.fr.football.domain.repository
+
+import com.papa.fr.football.domain.model.Match
+
+interface MatchRepository {
+    suspend fun getUpcomingMatches(uniqueTournamentId: Int, seasonId: Int): List<Match>
+}

--- a/app/src/main/java/com/papa/fr/football/domain/usecase/GetUpcomingMatchesUseCase.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/usecase/GetUpcomingMatchesUseCase.kt
@@ -1,0 +1,10 @@
+package com.papa.fr.football.domain.usecase
+
+import com.papa.fr.football.domain.model.Match
+import com.papa.fr.football.domain.repository.MatchRepository
+
+class GetUpcomingMatchesUseCase(private val matchRepository: MatchRepository) {
+    suspend operator fun invoke(uniqueTournamentId: Int, seasonId: Int): List<Match> {
+        return matchRepository.getUpcomingMatches(uniqueTournamentId, seasonId)
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/matches/MatchesAdapter.kt
+++ b/app/src/main/java/com/papa/fr/football/matches/MatchesAdapter.kt
@@ -54,11 +54,14 @@ class MatchesAdapter : ListAdapter<MatchUiModel, RecyclerView.ViewHolder>(DIFF_C
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: MatchUiModel.Future) = with(binding) {
-            iltHome.setTitle(item.homeTeam)
-            iltHome.setIndicatorActive(item.homeStartTime.contains("Today"))
-            iltAway.setTitle(item.awayTeam)
-            tvHomeStartTime.text = item.homeStartTime
-            tvAwayStartTime.text = item.awayStartTime
+            iltHome.setTitle(item.homeTeamName)
+            iltHome.setIndicatorActive(item.isToday)
+            iltHome.setLogoBase64(item.homeLogoBase64)
+            iltAway.setTitle(item.awayTeamName)
+            iltAway.setIndicatorActive(false)
+            iltAway.setLogoBase64(item.awayLogoBase64)
+            tvHomeStartTime.text = item.startDateLabel
+            tvAwayStartTime.text = item.startTimeLabel
         }
     }
 
@@ -106,10 +109,14 @@ class MatchesAdapter : ListAdapter<MatchUiModel, RecyclerView.ViewHolder>(DIFF_C
 sealed class MatchUiModel(open val id: String) {
     data class Future(
         override val id: String,
-        val homeTeam: String,
-        val awayTeam: String,
-        val homeStartTime: String,
-        val awayStartTime: String = "--",
+        val homeTeamId: Int,
+        val homeTeamName: String,
+        val awayTeamId: Int,
+        val awayTeamName: String,
+        val startTimestamp: Long,
+        val startDateLabel: String,
+        val startTimeLabel: String,
+        val isToday: Boolean,
         val homeLogoBase64: String,
         val awayLogoBase64: String,
         val odds: Odds? = null,

--- a/app/src/main/java/com/papa/fr/football/matches/MatchesAdapter.kt
+++ b/app/src/main/java/com/papa/fr/football/matches/MatchesAdapter.kt
@@ -43,8 +43,12 @@ class MatchesAdapter : ListAdapter<MatchUiModel, RecyclerView.ViewHolder>(DIFF_C
         }
     }
 
-    fun submitMatches(matches: List<MatchUiModel>) {
-        submitList(matches)
+    fun submitMatches(matches: List<MatchUiModel>, onCommitted: (() -> Unit)? = null) {
+        if (onCommitted == null) {
+            submitList(matches)
+        } else {
+            submitList(matches, Runnable { onCommitted() })
+        }
     }
 
     private enum class ViewType { FUTURE, LIVE, PAST }

--- a/app/src/main/java/com/papa/fr/football/matches/MatchesListFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/matches/MatchesListFragment.kt
@@ -1,6 +1,7 @@
 package com.papa.fr.football.matches
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -71,7 +72,20 @@ class MatchesListFragment : Fragment() {
             MatchesTabType.LIVE, MatchesTabType.PAST -> emptyList()
         }
 
-        matchesAdapter.submitMatches(matches)
+        val shouldPreserveScroll = matchesAdapter.currentList.isNotEmpty() &&
+            matchesAdapter.currentList.map { it.id } == matches.map { it.id }
+
+        val savedState: Parcelable? = if (shouldPreserveScroll) {
+            binding.rvMatches.layoutManager?.onSaveInstanceState()
+        } else {
+            null
+        }
+
+        matchesAdapter.submitMatches(matches) {
+            if (savedState != null) {
+                binding.rvMatches.layoutManager?.onRestoreInstanceState(savedState)
+            }
+        }
 
         val placeholderText = when {
             matchesType == MatchesTabType.FUTURE && state.isMatchesLoading ->

--- a/app/src/main/java/com/papa/fr/football/matches/MatchesListFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/matches/MatchesListFragment.kt
@@ -25,7 +25,7 @@ class MatchesListFragment : Fragment() {
     private val binding: FragmentMatchesListBinding
         get() = requireNotNull(_binding)
 
-    private val scheduleViewModel: ScheduleViewModel by sharedViewModel(from = { requireParentFragment() })
+    private val scheduleViewModel: ScheduleViewModel by sharedViewModel()
     private val matchesAdapter = MatchesAdapter()
     private var lastErrorMessage: String? = null
     private lateinit var matchesType: MatchesTabType

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
@@ -59,7 +59,7 @@ class ScheduleFragment : Fragment() {
         binding.ddLeague.setPlaceholder(scheduleViewModel.defaultLeagueLabel())
 
         binding.btnSchedule.setOnClickListener {
-            scheduleViewModel.refreshSelectedLeagueData()
+            scheduleViewModel.refreshSchedule()
         }
 
         if (scheduleViewModel.uiState.value.seasonsByLeague.isEmpty()) {

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
@@ -16,7 +16,7 @@ import com.papa.fr.football.databinding.FragmentScheduleBinding
 import com.papa.fr.football.matches.MatchesListFragment
 import com.papa.fr.football.matches.MatchesTabType
 import kotlinx.coroutines.launch
-import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import java.util.Calendar
 import java.util.Locale
 
@@ -25,7 +25,7 @@ class ScheduleFragment : Fragment() {
     private var _binding: FragmentScheduleBinding? = null
     private val binding get() = _binding!!
 
-    private val scheduleViewModel: ScheduleViewModel by viewModel()
+    private val scheduleViewModel: ScheduleViewModel by sharedViewModel()
 
     private var lastSeasonIdsByLeague: Map<Int, List<Int>> = emptyMap()
     private var lastErrorMessage: String? = null

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleUiState.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleUiState.kt
@@ -15,4 +15,7 @@ data class ScheduleUiState(
     val isMatchesLoading: Boolean = false,
     val matchesErrorMessage: String? = null,
     val futureMatches: List<MatchUiModel.Future> = emptyList(),
+    val matchesByLeagueSeason: Map<Int, Map<Int, List<MatchUiModel.Future>>> = emptyMap(),
+    val matchErrorsByLeagueSeason: Map<Int, Map<Int, String?>> = emptyMap(),
+    val isDataLoaded: Boolean = false,
 )

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleUiState.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleUiState.kt
@@ -1,6 +1,7 @@
 package com.papa.fr.football.presentation.schedule
 
 import com.papa.fr.football.domain.model.Season
+import com.papa.fr.football.matches.MatchUiModel
 
 /**
  * UI representation of the available leagues and seasons backing the schedule screen.
@@ -8,5 +9,10 @@ import com.papa.fr.football.domain.model.Season
 data class ScheduleUiState(
     val isLoading: Boolean = false,
     val seasonsByLeague: Map<Int, List<Season>> = emptyMap(),
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val selectedLeagueId: Int? = null,
+    val selectedSeasonId: Int? = null,
+    val isMatchesLoading: Boolean = false,
+    val matchesErrorMessage: String? = null,
+    val futureMatches: List<MatchUiModel.Future> = emptyList(),
 )

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleViewModel.kt
@@ -4,8 +4,16 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.papa.fr.football.R
 import com.papa.fr.football.common.dropdown.LeagueItem
+import com.papa.fr.football.domain.model.Match
 import com.papa.fr.football.domain.model.Season
 import com.papa.fr.football.domain.usecase.GetSeasonsUseCase
+import com.papa.fr.football.domain.usecase.GetUpcomingMatchesUseCase
+import com.papa.fr.football.matches.MatchUiModel
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,11 +24,14 @@ import kotlinx.coroutines.launch
  * Coordinates league metadata and season loading for the schedule feature.
  */
 class ScheduleViewModel(
-    private val getSeasonsUseCase: GetSeasonsUseCase
+    private val getSeasonsUseCase: GetSeasonsUseCase,
+    private val getUpcomingMatchesUseCase: GetUpcomingMatchesUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ScheduleUiState())
     val uiState: StateFlow<ScheduleUiState> = _uiState.asStateFlow()
+
+    private var matchesJob: Job? = null
 
     private val _leagueItems = MutableStateFlow(
         listOf(
@@ -83,12 +94,19 @@ class ScheduleViewModel(
                 }
             }
 
+            val (leagueId, seasonId) = determineSelection(currentSeasons)
             _uiState.update {
                 it.copy(
                     isLoading = false,
                     seasonsByLeague = currentSeasons,
-                    errorMessage = encounteredError
+                    errorMessage = encounteredError,
+                    selectedLeagueId = leagueId,
+                    selectedSeasonId = seasonId,
                 )
+            }
+
+            if (leagueId != null && seasonId != null) {
+                loadUpcomingMatches(leagueId, seasonId)
             }
         }
     }
@@ -98,23 +116,162 @@ class ScheduleViewModel(
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
 
             val result = runCatching { getSeasonsUseCase(leagueId) }
+            result.onSuccess { seasons ->
+                _uiState.update { state ->
+                    val updatedSeasons = state.seasonsByLeague + (leagueId to seasons)
+                    val selectedSeasonId = when {
+                        state.selectedLeagueId != leagueId -> state.selectedSeasonId
+                        seasons.any { it.id == state.selectedSeasonId } -> state.selectedSeasonId
+                        else -> seasons.firstOrNull()?.id
+                    }
+                    state.copy(
+                        isLoading = false,
+                        seasonsByLeague = updatedSeasons,
+                        errorMessage = null,
+                        selectedLeagueId = state.selectedLeagueId ?: leagueId,
+                        selectedSeasonId = selectedSeasonId,
+                    )
+                }
+
+                val selectedSeasonId = _uiState.value.selectedSeasonId
+                val selectedLeagueId = _uiState.value.selectedLeagueId
+                if (selectedLeagueId == leagueId && selectedSeasonId != null) {
+                    loadUpcomingMatches(leagueId, selectedSeasonId)
+                }
+            }
+            result.onFailure { throwable ->
+                _uiState.update { state ->
+                    state.copy(
+                        isLoading = false,
+                        errorMessage = throwable.message,
+                    )
+                }
+            }
+        }
+    }
+
+    fun onLeagueSelected(leagueId: Int) {
+        val seasons = seasonsForLeague(leagueId)
+        val previousState = _uiState.value
+        _uiState.update { it.copy(selectedLeagueId = leagueId) }
+
+        if (seasons.isEmpty()) {
+            loadSeasonsForLeague(leagueId)
+            return
+        }
+
+        val currentSeasonId = previousState.selectedSeasonId
+        val validSeasonId = seasons.firstOrNull { it.id == currentSeasonId }?.id
+            ?: seasons.firstOrNull()?.id
+
+        if (validSeasonId != currentSeasonId) {
+            _uiState.update { it.copy(selectedSeasonId = validSeasonId) }
+        }
+
+        if (validSeasonId != null) {
+            loadUpcomingMatches(leagueId, validSeasonId)
+        }
+    }
+
+    fun onSeasonSelected(seasonId: Int) {
+        val leagueId = _uiState.value.selectedLeagueId ?: return
+        if (_uiState.value.selectedSeasonId == seasonId) {
+            return
+        }
+        _uiState.update { it.copy(selectedSeasonId = seasonId) }
+        loadUpcomingMatches(leagueId, seasonId)
+    }
+
+    fun refreshSelectedLeagueData() {
+        val leagueId = _uiState.value.selectedLeagueId ?: _leagueItems.value.firstOrNull()?.id
+        val seasonId = _uiState.value.selectedSeasonId
+
+        if (leagueId != null) {
+            loadSeasonsForLeague(leagueId)
+        }
+
+        if (leagueId != null && seasonId != null) {
+            loadUpcomingMatches(leagueId, seasonId)
+        }
+    }
+
+    private fun loadUpcomingMatches(leagueId: Int, seasonId: Int) {
+        matchesJob?.cancel()
+        matchesJob = viewModelScope.launch {
+            _uiState.update {
+                it.copy(isMatchesLoading = true, matchesErrorMessage = null)
+            }
+
+            val result = runCatching { getUpcomingMatchesUseCase(leagueId, seasonId) }
             _uiState.update { state ->
                 result.fold(
-                    onSuccess = { seasons ->
+                    onSuccess = { matches ->
                         state.copy(
-                            isLoading = false,
-                            seasonsByLeague = state.seasonsByLeague + (leagueId to seasons),
-                            errorMessage = null
+                            isMatchesLoading = false,
+                            matchesErrorMessage = null,
+                            futureMatches = matches.map { it.toUiModel() },
                         )
                     },
                     onFailure = { throwable ->
                         state.copy(
-                            isLoading = false,
-                            errorMessage = throwable.message
+                            isMatchesLoading = false,
+                            matchesErrorMessage = throwable.message,
+                            futureMatches = emptyList(),
                         )
                     }
                 )
             }
         }
+    }
+
+    private fun determineSelection(seasonsByLeague: Map<Int, List<Season>>): Pair<Int?, Int?> {
+        val availableLeagueIds = _leagueItems.value.map { it.id }
+        val state = _uiState.value
+        val leagueId = state.selectedLeagueId
+            ?.takeIf { seasonsByLeague[it].orEmpty().isNotEmpty() }
+            ?: availableLeagueIds.firstOrNull { seasonsByLeague[it].orEmpty().isNotEmpty() }
+
+        val seasons = leagueId?.let { seasonsByLeague[it] }.orEmpty()
+        val seasonId = state.selectedSeasonId?.takeIf { id ->
+            seasons.any { it.id == id }
+        } ?: seasons.firstOrNull()?.id
+
+        return leagueId to seasonId
+    }
+
+    private fun Match.toUiModel(): MatchUiModel.Future {
+        val instant = toInstant(startTimestamp)
+        val zonedDateTime = instant.atZone(ZoneId.systemDefault())
+        val dateLabel = zonedDateTime.format(DATE_FORMATTER)
+        val timeLabel = zonedDateTime.format(TIME_FORMATTER)
+        val isToday = zonedDateTime.toLocalDate() == LocalDate.now()
+
+        return MatchUiModel.Future(
+            id = id,
+            homeTeamId = homeTeam.id,
+            homeTeamName = homeTeam.name,
+            awayTeamId = awayTeam.id,
+            awayTeamName = awayTeam.name,
+            startTimestamp = startTimestamp,
+            startDateLabel = dateLabel,
+            startTimeLabel = timeLabel,
+            isToday = isToday,
+            homeLogoBase64 = homeTeam.logoBase64,
+            awayLogoBase64 = awayTeam.logoBase64,
+            odds = null,
+        )
+    }
+
+    private fun toInstant(timestamp: Long): Instant {
+        return if (timestamp < 1_000_000_000_000L) {
+            Instant.ofEpochSecond(timestamp)
+        } else {
+            Instant.ofEpochMilli(timestamp)
+        }
+    }
+
+    companion object {
+        private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("MMM dd")
+        private val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="matches_tab_past">Past</string>
     <string name="matches_placeholder_format">This is the %1$s matches screen.</string>
     <string name="matches_placeholder_empty">There are currently no matches to display.</string>
+    <string name="matches_placeholder_loading">Loading upcoming matches…</string>
     <string name="bottom_nav_schedule">Schedule</string>
     <string name="bottom_nav_highlights">Highlights</string>
     <string name="bottom_nav_teams">Teams</string>


### PR DESCRIPTION
## Summary
- add DTOs, repositories, and use cases to fetch season events and team logos
- extend schedule state and view model to track selected league/season and load upcoming matches
- update schedule and matches UI to render API data with decoded base64 logos and improved placeholders

## Testing
- `./gradlew test --console=plain --no-daemon` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0ea5aab0832d9ba90c5c63d108a9