### PR TITLE
Add live matches feed with team logo provider

### DIFF
--- a/app/src/main/java/com/papa/fr/football/data/mapper/EventMapper.kt
+++ b/app/src/main/java/com/papa/fr/football/data/mapper/EventMapper.kt
@@ -1,6 +1,8 @@
 package com.papa.fr.football.data.mapper
 
 import com.papa.fr.football.data.remote.dto.EventDto
+import com.papa.fr.football.data.remote.dto.LiveEventDto
+import com.papa.fr.football.domain.model.LiveMatch
 import com.papa.fr.football.domain.model.Match
 import com.papa.fr.football.domain.model.MatchTeam
 
@@ -21,3 +23,32 @@ fun EventDto.toDomain(homeLogoBase64: String?, awayLogoBase64: String?): Match {
         ),
     )
 }
+
+fun LiveEventDto.toLiveDomain(
+    homeLogoBase64: String?,
+    awayLogoBase64: String?,
+): LiveMatch {
+    val fallbackId = listOfNotNull(homeTeam?.id, awayTeam?.id)
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(prefix = "live-", separator = "-")
+        ?: "live-unknown"
+
+    return LiveMatch(
+        id = (id ?: 0L).takeIf { it != 0L }?.toString() ?: fallbackId,
+        homeTeam = MatchTeam(
+            id = homeTeam?.id ?: -1,
+            name = homeTeam?.name.orEmpty(),
+            logoBase64 = homeLogoBase64.orEmpty(),
+        ),
+        awayTeam = MatchTeam(
+            id = awayTeam?.id ?: -1,
+            name = awayTeam?.name.orEmpty(),
+            logoBase64 = awayLogoBase64.orEmpty(),
+        ),
+        homeScore = homeScore?.current ?: 0,
+        awayScore = awayScore?.current ?: 0,
+        status = statusDescription?.ifBlank { DEFAULT_LIVE_STATUS } ?: DEFAULT_LIVE_STATUS,
+    )
+}
+
+private const val DEFAULT_LIVE_STATUS = "Live"

--- a/app/src/main/java/com/papa/fr/football/data/remote/LiveEventsApiService.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/LiveEventsApiService.kt
@@ -1,0 +1,17 @@
+package com.papa.fr.football.data.remote
+
+import com.papa.fr.football.data.remote.dto.LiveEventsResponseDto
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.http.encodedPath
+
+class LiveEventsApiService(private val httpClient: HttpClient) {
+    suspend fun getLiveSchedule(sportId: Int): LiveEventsResponseDto {
+        return httpClient.get {
+            url { encodedPath = "v1/events/schedule/live" }
+            parameter("sport_id", sportId)
+        }.body()
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/data/remote/dto/LiveEventsResponseDto.kt
+++ b/app/src/main/java/com/papa/fr/football/data/remote/dto/LiveEventsResponseDto.kt
@@ -1,0 +1,40 @@
+package com.papa.fr.football.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LiveEventsResponseDto(
+    @SerialName("data")
+    val data: List<LiveEventDto> = emptyList(),
+)
+
+@Serializable
+data class LiveEventDto(
+    @SerialName("id")
+    val id: Long? = null,
+    @SerialName("homeTeam")
+    val homeTeam: LiveEventTeamDto? = null,
+    @SerialName("awayTeam")
+    val awayTeam: LiveEventTeamDto? = null,
+    @SerialName("homeScore")
+    val homeScore: LiveEventScoreDto? = null,
+    @SerialName("awayScore")
+    val awayScore: LiveEventScoreDto? = null,
+    @SerialName("statusDescription")
+    val statusDescription: String? = null,
+)
+
+@Serializable
+data class LiveEventTeamDto(
+    @SerialName("id")
+    val id: Int? = null,
+    @SerialName("name")
+    val name: String? = null,
+)
+
+@Serializable
+data class LiveEventScoreDto(
+    @SerialName("current")
+    val current: Int? = null,
+)

--- a/app/src/main/java/com/papa/fr/football/data/repository/MatchRepositoryImpl.kt
+++ b/app/src/main/java/com/papa/fr/football/data/repository/MatchRepositoryImpl.kt
@@ -1,32 +1,20 @@
 package com.papa.fr.football.data.repository
 
-import android.util.Base64
 import com.papa.fr.football.data.mapper.toDomain
+import com.papa.fr.football.data.mapper.toLiveDomain
+import com.papa.fr.football.data.remote.LiveEventsApiService
 import com.papa.fr.football.data.remote.SeasonApiService
-import com.papa.fr.football.data.remote.TeamApiService
-import com.papa.fr.football.data.remote.TeamLogoRaw
-import com.papa.fr.football.data.remote.dto.TeamLogoResponseDto
+import com.papa.fr.football.domain.model.LiveMatch
 import com.papa.fr.football.domain.model.Match
 import com.papa.fr.football.domain.repository.MatchRepository
-import io.ktor.http.ContentType
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.json.Json
-import java.util.concurrent.ConcurrentHashMap
 
 class MatchRepositoryImpl(
     private val seasonApiService: SeasonApiService,
-    private val teamApiService: TeamApiService,
+    private val liveEventsApiService: LiveEventsApiService,
+    private val teamLogoProvider: TeamLogoProvider,
 ) : MatchRepository {
-
-    private val teamLogoCache = ConcurrentHashMap<Int, String>()
-    private val logoMutex = Mutex()
-
-    @Volatile
-    private var nextLogoRequestAt: Long = 0L
 
     override suspend fun getUpcomingMatches(uniqueTournamentId: Int, seasonId: Int): List<Match> =
         coroutineScope {
@@ -44,7 +32,7 @@ class MatchRepositoryImpl(
             }.toSet()
 
             val logos = teamIds.associateWith { teamId ->
-                async { fetchTeamLogo(teamId) }
+                async { teamLogoProvider.getTeamLogo(teamId) }
             }.mapValues { (_, deferred) -> deferred.await() }
 
             events.map { event ->
@@ -55,96 +43,28 @@ class MatchRepositoryImpl(
             }
         }
 
-    private suspend fun fetchTeamLogo(teamId: Int): String {
-        teamLogoCache[teamId]?.let { return it }
+    override suspend fun getLiveMatches(sportId: Int): List<LiveMatch> = coroutineScope {
+        val events = liveEventsApiService
+            .getLiveSchedule(sportId)
+            .data
 
-        var cachedLogo: String? = null
-        var waitDurationMs = 0L
-
-        logoMutex.withLock {
-            cachedLogo = teamLogoCache[teamId]
-            if (cachedLogo != null) {
-                return@withLock
-            }
-
-            val now = System.currentTimeMillis()
-            val scheduledStart = maxOf(now, nextLogoRequestAt)
-            waitDurationMs = (scheduledStart - now).coerceAtLeast(0L)
-            nextLogoRequestAt = scheduledStart + LOGO_REQUEST_INTERVAL_MS
+        if (events.isEmpty()) {
+            return@coroutineScope emptyList()
         }
 
-        cachedLogo?.let { return it }
+        val teamIds = events.flatMap { event ->
+            listOfNotNull(event.homeTeam?.id, event.awayTeam?.id)
+        }.toSet()
 
-        if (waitDurationMs > 0L) {
-            delay(waitDurationMs)
+        val logos = teamIds.associateWith { teamId ->
+            async { teamLogoProvider.getTeamLogo(teamId) }
+        }.mapValues { (_, deferred) -> deferred.await() }
+
+        events.map { event ->
+            event.toLiveDomain(
+                homeLogoBase64 = event.homeTeam?.id?.let { logos[it] },
+                awayLogoBase64 = event.awayTeam?.id?.let { logos[it] },
+            )
         }
-
-        val sanitizedLogo = runCatching {
-            teamApiService.getTeamLogo(teamId).toSanitizedBase64()
-        }.getOrElse { "" }
-
-        if (sanitizedLogo.isNotBlank()) {
-            teamLogoCache[teamId] = sanitizedLogo
-        }
-
-        return sanitizedLogo
-    }
-
-    private fun String?.sanitizeBase64(): String {
-        if (this.isNullOrBlank()) return ""
-        val delimiter = "base64,"
-        val index = indexOf(delimiter)
-        val trimmed = if (index >= 0) {
-            substring(index + delimiter.length)
-        } else {
-            this
-        }
-        return trimmed.trim()
-    }
-
-    private fun TeamLogoRaw.toSanitizedBase64(): String {
-        val normalizedContentType = contentType?.withoutParameters()
-
-        if (normalizedContentType != null && normalizedContentType.match(ContentType.Image.Any)) {
-            return body.encodeToBase64()
-        }
-
-        val rawText = body.decodeToString().trim()
-        if (rawText.isEmpty()) return ""
-
-        if (normalizedContentType == ContentType.Application.Json || rawText.startsWith("{")) {
-            val base64FromJson = runCatching {
-                json.decodeFromString<TeamLogoResponseDto>(rawText).data
-            }.getOrNull()
-            base64FromJson?.sanitizeBase64()?.takeIf { it.isLikelyBase64() }?.let { return it }
-        }
-
-        val sanitized = rawText.sanitizeBase64()
-        if (sanitized.isLikelyBase64()) {
-            return sanitized
-        }
-
-        return body.encodeToBase64()
-    }
-
-    private fun ByteArray.encodeToBase64(): String {
-        if (isEmpty()) return ""
-        return Base64.encodeToString(this, Base64.NO_WRAP)
-    }
-
-    private fun String.isLikelyBase64(): Boolean {
-        if (isBlank() || length < MIN_BASE64_LENGTH) return false
-        val candidate = replace("\n", "").replace("\r", "")
-        return !candidate.any { !it.isBase64Char() }
-    }
-
-    private fun Char.isBase64Char(): Boolean {
-        return isLetterOrDigit() || this == '+' || this == '/' || this == '=' || this == '-' || this == '_'
-    }
-
-    private companion object {
-        private const val LOGO_REQUEST_INTERVAL_MS = 650L
-        private const val MIN_BASE64_LENGTH = 32
-        private val json = Json { ignoreUnknownKeys = true }
     }
 }

--- a/app/src/main/java/com/papa/fr/football/data/repository/TeamLogoProvider.kt
+++ b/app/src/main/java/com/papa/fr/football/data/repository/TeamLogoProvider.kt
@@ -57,6 +57,8 @@ class TeamLogoProvider(
         return sanitizedLogo
     }
 
+    fun peekCachedLogo(teamId: Int): String? = teamLogoCache[teamId]
+
     private fun String?.sanitizeBase64(): String {
         if (this.isNullOrBlank()) return ""
         val delimiter = "base64,"

--- a/app/src/main/java/com/papa/fr/football/data/repository/TeamLogoProvider.kt
+++ b/app/src/main/java/com/papa/fr/football/data/repository/TeamLogoProvider.kt
@@ -1,0 +1,117 @@
+package com.papa.fr.football.data.repository
+
+import android.util.Base64
+import com.papa.fr.football.data.remote.TeamApiService
+import com.papa.fr.football.data.remote.TeamLogoRaw
+import com.papa.fr.football.data.remote.dto.TeamLogoResponseDto
+import io.ktor.http.ContentType
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import java.util.concurrent.ConcurrentHashMap
+
+class TeamLogoProvider(
+    private val teamApiService: TeamApiService,
+    private val timeProvider: () -> Long = System::currentTimeMillis,
+) {
+
+    private val teamLogoCache = ConcurrentHashMap<Int, String>()
+    private val logoMutex = Mutex()
+
+    @Volatile
+    private var nextLogoRequestAt: Long = 0L
+
+    suspend fun getTeamLogo(teamId: Int): String {
+        teamLogoCache[teamId]?.let { return it }
+
+        var cachedLogo: String? = null
+        var waitDurationMs = 0L
+
+        logoMutex.withLock {
+            cachedLogo = teamLogoCache[teamId]
+            if (cachedLogo != null) {
+                return@withLock
+            }
+
+            val now = timeProvider()
+            val scheduledStart = maxOf(now, nextLogoRequestAt)
+            waitDurationMs = (scheduledStart - now).coerceAtLeast(0L)
+            nextLogoRequestAt = scheduledStart + LOGO_REQUEST_INTERVAL_MS
+        }
+
+        cachedLogo?.let { return it }
+
+        if (waitDurationMs > 0L) {
+            delay(waitDurationMs)
+        }
+
+        val sanitizedLogo = runCatching {
+            teamApiService.getTeamLogo(teamId).toSanitizedBase64()
+        }.getOrElse { "" }
+
+        if (sanitizedLogo.isNotBlank()) {
+            teamLogoCache[teamId] = sanitizedLogo
+        }
+
+        return sanitizedLogo
+    }
+
+    private fun String?.sanitizeBase64(): String {
+        if (this.isNullOrBlank()) return ""
+        val delimiter = "base64,"
+        val index = indexOf(delimiter)
+        val trimmed = if (index >= 0) {
+            substring(index + delimiter.length)
+        } else {
+            this
+        }
+        return trimmed.trim()
+    }
+
+    private fun TeamLogoRaw.toSanitizedBase64(): String {
+        val normalizedContentType = contentType?.withoutParameters()
+
+        if (normalizedContentType != null && normalizedContentType.match(ContentType.Image.Any)) {
+            return body.encodeToBase64()
+        }
+
+        val rawText = body.decodeToString().trim()
+        if (rawText.isEmpty()) return ""
+
+        if (normalizedContentType == ContentType.Application.Json || rawText.startsWith("{")) {
+            val base64FromJson = runCatching {
+                json.decodeFromString<TeamLogoResponseDto>(rawText).data
+            }.getOrNull()
+            base64FromJson?.sanitizeBase64()?.takeIf { it.isLikelyBase64() }?.let { return it }
+        }
+
+        val sanitized = rawText.sanitizeBase64()
+        if (sanitized.isLikelyBase64()) {
+            return sanitized
+        }
+
+        return body.encodeToBase64()
+    }
+
+    private fun ByteArray.encodeToBase64(): String {
+        if (isEmpty()) return ""
+        return Base64.encodeToString(this, Base64.NO_WRAP)
+    }
+
+    private fun String.isLikelyBase64(): Boolean {
+        if (isBlank() || length < MIN_BASE64_LENGTH) return false
+        val candidate = replace("\n", "").replace("\r", "")
+        return !candidate.any { !it.isBase64Char() }
+    }
+
+    private fun Char.isBase64Char(): Boolean {
+        return isLetterOrDigit() || this == '+' || this == '/' || this == '=' || this == '-' || this == '_'
+    }
+
+    private companion object {
+        private const val LOGO_REQUEST_INTERVAL_MS = 650L
+        private const val MIN_BASE64_LENGTH = 32
+        private val json = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/di/AppModules.kt
+++ b/app/src/main/java/com/papa/fr/football/di/AppModules.kt
@@ -2,12 +2,15 @@ package com.papa.fr.football.di
 
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
+import com.papa.fr.football.data.remote.LiveEventsApiService
 import com.papa.fr.football.data.remote.SeasonApiService
 import com.papa.fr.football.data.remote.TeamApiService
 import com.papa.fr.football.data.repository.MatchRepositoryImpl
 import com.papa.fr.football.data.repository.SeasonRepositoryImpl
+import com.papa.fr.football.data.repository.TeamLogoProvider
 import com.papa.fr.football.domain.repository.MatchRepository
 import com.papa.fr.football.domain.repository.SeasonRepository
+import com.papa.fr.football.domain.usecase.GetLiveMatchesUseCase
 import com.papa.fr.football.domain.usecase.GetSeasonsUseCase
 import com.papa.fr.football.domain.usecase.GetUpcomingMatchesUseCase
 import com.papa.fr.football.presentation.schedule.ScheduleViewModel
@@ -68,15 +71,18 @@ val networkModule = module {
 val dataModule = module {
     single { SeasonApiService(get()) }
     single { TeamApiService(get()) }
+    single { LiveEventsApiService(get()) }
+    single { TeamLogoProvider(get()) }
     single<SeasonRepository> { SeasonRepositoryImpl(get()) }
-    single<MatchRepository> { MatchRepositoryImpl(get(), get()) }
+    single<MatchRepository> { MatchRepositoryImpl(get(), get(), get()) }
 }
 
 val domainModule = module {
     factory { GetSeasonsUseCase(get()) }
     factory { GetUpcomingMatchesUseCase(get()) }
+    factory { GetLiveMatchesUseCase(get()) }
 }
 
 val presentationModule = module {
-    viewModel { ScheduleViewModel(get(), get()) }
+    viewModel { ScheduleViewModel(get(), get(), get()) }
 }

--- a/app/src/main/java/com/papa/fr/football/domain/model/LiveMatch.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/model/LiveMatch.kt
@@ -1,0 +1,13 @@
+package com.papa.fr.football.domain.model
+
+/**
+ * Domain representation of an in-progress match event.
+ */
+data class LiveMatch(
+    val id: String,
+    val homeTeam: MatchTeam,
+    val awayTeam: MatchTeam,
+    val homeScore: Int,
+    val awayScore: Int,
+    val status: String,
+)

--- a/app/src/main/java/com/papa/fr/football/domain/repository/MatchRepository.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/repository/MatchRepository.kt
@@ -1,7 +1,9 @@
 package com.papa.fr.football.domain.repository
 
+import com.papa.fr.football.domain.model.LiveMatch
 import com.papa.fr.football.domain.model.Match
 
 interface MatchRepository {
     suspend fun getUpcomingMatches(uniqueTournamentId: Int, seasonId: Int): List<Match>
+    suspend fun getLiveMatches(sportId: Int): List<LiveMatch>
 }

--- a/app/src/main/java/com/papa/fr/football/domain/repository/MatchRepository.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/repository/MatchRepository.kt
@@ -2,8 +2,9 @@ package com.papa.fr.football.domain.repository
 
 import com.papa.fr.football.domain.model.LiveMatch
 import com.papa.fr.football.domain.model.Match
+import kotlinx.coroutines.flow.Flow
 
 interface MatchRepository {
     suspend fun getUpcomingMatches(uniqueTournamentId: Int, seasonId: Int): List<Match>
-    suspend fun getLiveMatches(sportId: Int): List<LiveMatch>
+    fun getLiveMatches(sportId: Int): Flow<List<LiveMatch>>
 }

--- a/app/src/main/java/com/papa/fr/football/domain/repository/MatchRepository.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/repository/MatchRepository.kt
@@ -5,6 +5,6 @@ import com.papa.fr.football.domain.model.Match
 import kotlinx.coroutines.flow.Flow
 
 interface MatchRepository {
-    suspend fun getUpcomingMatches(uniqueTournamentId: Int, seasonId: Int): List<Match>
+    fun getUpcomingMatches(uniqueTournamentId: Int, seasonId: Int): Flow<List<Match>>
     fun getLiveMatches(sportId: Int): Flow<List<LiveMatch>>
 }

--- a/app/src/main/java/com/papa/fr/football/domain/usecase/GetLiveMatchesUseCase.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/usecase/GetLiveMatchesUseCase.kt
@@ -2,9 +2,9 @@ package com.papa.fr.football.domain.usecase
 
 import com.papa.fr.football.domain.model.LiveMatch
 import com.papa.fr.football.domain.repository.MatchRepository
+import kotlinx.coroutines.flow.Flow
 
 class GetLiveMatchesUseCase(private val matchRepository: MatchRepository) {
-    suspend operator fun invoke(sportId: Int): List<LiveMatch> {
-        return matchRepository.getLiveMatches(sportId)
-    }
+    operator fun invoke(sportId: Int): Flow<List<LiveMatch>> =
+        matchRepository.getLiveMatches(sportId)
 }

--- a/app/src/main/java/com/papa/fr/football/domain/usecase/GetLiveMatchesUseCase.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/usecase/GetLiveMatchesUseCase.kt
@@ -1,0 +1,10 @@
+package com.papa.fr.football.domain.usecase
+
+import com.papa.fr.football.domain.model.LiveMatch
+import com.papa.fr.football.domain.repository.MatchRepository
+
+class GetLiveMatchesUseCase(private val matchRepository: MatchRepository) {
+    suspend operator fun invoke(sportId: Int): List<LiveMatch> {
+        return matchRepository.getLiveMatches(sportId)
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/domain/usecase/GetUpcomingMatchesUseCase.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/usecase/GetUpcomingMatchesUseCase.kt
@@ -2,9 +2,9 @@ package com.papa.fr.football.domain.usecase
 
 import com.papa.fr.football.domain.model.Match
 import com.papa.fr.football.domain.repository.MatchRepository
+import kotlinx.coroutines.flow.Flow
 
 class GetUpcomingMatchesUseCase(private val matchRepository: MatchRepository) {
-    suspend operator fun invoke(uniqueTournamentId: Int, seasonId: Int): List<Match> {
-        return matchRepository.getUpcomingMatches(uniqueTournamentId, seasonId)
-    }
+    operator fun invoke(uniqueTournamentId: Int, seasonId: Int): Flow<List<Match>> =
+        matchRepository.getUpcomingMatches(uniqueTournamentId, seasonId)
 }

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleFragment.kt
@@ -17,6 +17,8 @@ import com.papa.fr.football.presentation.schedule.matches.MatchesListFragment
 import com.papa.fr.football.presentation.schedule.matches.MatchesTabType
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.activityViewModel
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Locale
 
@@ -32,6 +34,8 @@ class ScheduleFragment : Fragment() {
     private var lastSeasonIdsByLeague: Map<Int, List<Int>> = emptyMap()
     private var lastErrorMessage: String? = null
     private var lastSelectedLeagueId: Int? = null
+    private val lastUpdatedFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm", Locale.getDefault())
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -93,6 +97,7 @@ class ScheduleFragment : Fragment() {
         maybeUpdateSeasonData(state)
         maybeSyncSelectedLeague(state)
         maybeShowSeasonError(state)
+        updateLastUpdatedLabel(state)
     }
 
     private fun maybeUpdateSeasonData(state: ScheduleUiState) {
@@ -194,6 +199,15 @@ class ScheduleFragment : Fragment() {
         val startYear = calendar.get(Calendar.YEAR) % 100
         val endYear = (startYear + 1) % 100
         return String.format(Locale.getDefault(), "%02d/%02d", startYear, endYear)
+    }
+
+    private fun updateLastUpdatedLabel(state: ScheduleUiState) {
+        val buttonLabel = state.lastUpdatedAt?.let { instant ->
+            val formattedDate = lastUpdatedFormatter.format(instant.atZone(ZoneId.systemDefault()))
+            getString(R.string.schedule_last_updated, formattedDate)
+        } ?: getString(R.string.schedule_last_updated_placeholder)
+
+        binding.btnSchedule.text = buttonLabel
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleUiState.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleUiState.kt
@@ -17,5 +17,8 @@ data class ScheduleUiState(
     val futureMatches: List<MatchUiModel.Future> = emptyList(),
     val matchesByLeagueSeason: Map<Int, Map<Int, List<MatchUiModel.Future>>> = emptyMap(),
     val matchErrorsByLeagueSeason: Map<Int, Map<Int, String?>> = emptyMap(),
+    val liveMatches: List<MatchUiModel.Live> = emptyList(),
+    val isLiveMatchesLoading: Boolean = false,
+    val liveMatchesErrorMessage: String? = null,
     val isDataLoaded: Boolean = false,
 )

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleUiState.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleUiState.kt
@@ -2,6 +2,7 @@ package com.papa.fr.football.presentation.schedule
 
 import com.papa.fr.football.domain.model.Season
 import com.papa.fr.football.presentation.schedule.matches.MatchUiModel
+import java.time.Instant
 
 /**
  * UI representation of the available leagues and seasons backing the schedule screen.
@@ -21,4 +22,5 @@ data class ScheduleUiState(
     val isLiveMatchesLoading: Boolean = false,
     val liveMatchesErrorMessage: String? = null,
     val isDataLoaded: Boolean = false,
+    val lastUpdatedAt: Instant? = null,
 )

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleViewModel.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/ScheduleViewModel.kt
@@ -91,10 +91,14 @@ class ScheduleViewModel(
      * Loads seasons for every league and progressively emits match updates as each response arrives.
      */
     fun loadAllLeagueSeasons(forceRefresh: Boolean = false) {
+        val refreshInstant = Instant.now()
         loadLiveMatches(forceRefresh)
         if (!forceRefresh && _uiState.value.isDataLoaded) {
+            _uiState.update { it.copy(lastUpdatedAt = refreshInstant) }
             return
         }
+
+        _uiState.update { it.copy(lastUpdatedAt = refreshInstant) }
 
         viewModelScope.launch {
             val previousState = _uiState.value
@@ -118,6 +122,7 @@ class ScheduleViewModel(
                     matchesByLeagueSeason = emptyMap(),
                     matchErrorsByLeagueSeason = emptyMap(),
                     isDataLoaded = false,
+                    lastUpdatedAt = refreshInstant,
                 )
             }
 

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/matches/MatchesAdapter.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/matches/MatchesAdapter.kt
@@ -73,12 +73,12 @@ class MatchesAdapter : ListAdapter<MatchUiModel, RecyclerView.ViewHolder>(DIFF_C
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: MatchUiModel.Live) = with(binding) {
-//            tvLiveMinute.text = item.contextText
-//            tvLiveHome.text = item.homeTeam
-//            tvLiveAway.text = item.awayTeam
-//            tvLiveScore.text = item.score
-//            tvLiveTime.text = item.elapsed
-//            tvLiveStatus.text = item.status
+            iltHome.setTitle(item.homeTeamName)
+            iltHome.setLogoBase64(item.homeLogoBase64)
+            iltAway.setTitle(item.awayTeamName)
+            iltAway.setLogoBase64(item.awayLogoBase64)
+            tvHomeStatus.text = item.statusLabel
+            tvScore.text = item.scoreLabel
         }
     }
 
@@ -127,13 +127,19 @@ sealed class MatchUiModel(open val id: String) {
 
     data class Live(
         override val id: String,
-        val homeTeam: String,
-        val awayTeam: String,
-        val score: String,
-        val contextText: String,
-        val elapsed: String,
-        val status: String,
-    ) : MatchUiModel(id)
+        val homeTeamId: Int,
+        val homeTeamName: String,
+        val awayTeamId: Int,
+        val awayTeamName: String,
+        val homeScore: Int,
+        val awayScore: Int,
+        val homeLogoBase64: String,
+        val awayLogoBase64: String,
+        val statusLabel: String,
+    ) : MatchUiModel(id) {
+        val scoreLabel: String
+            get() = "$homeScore:$awayScore"
+    }
 
     data class Past(
         override val id: String,

--- a/app/src/main/java/com/papa/fr/football/presentation/schedule/matches/MatchesListFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/schedule/matches/MatchesListFragment.kt
@@ -147,7 +147,8 @@ sealed interface MatchesTabType {
 
 private fun MatchesListFragment.matchesFor(state: ScheduleUiState): List<MatchUiModel> = when (matchesType) {
     MatchesTabType.Future -> state.futureMatches
-    MatchesTabType.Live, MatchesTabType.Past -> emptyList()
+    MatchesTabType.Live -> state.liveMatches
+    MatchesTabType.Past -> emptyList()
 }
 
 private fun MatchesListFragment.placeholderTextFor(state: ScheduleUiState): String = when (matchesType) {
@@ -157,7 +158,13 @@ private fun MatchesListFragment.placeholderTextFor(state: ScheduleUiState): Stri
         else -> getString(R.string.matches_placeholder_empty)
     }
 
-    MatchesTabType.Live, MatchesTabType.Past -> getString(
+    MatchesTabType.Live -> when {
+        state.isLiveMatchesLoading -> getString(R.string.matches_placeholder_loading_live)
+        !state.liveMatchesErrorMessage.isNullOrBlank() -> state.liveMatchesErrorMessage
+        else -> getString(R.string.matches_placeholder_empty_live)
+    }
+
+    MatchesTabType.Past -> getString(
         R.string.matches_placeholder_format,
         matchesType.storageKey.lowercase(Locale.getDefault())
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="matches_placeholder_format">This is the %1$s matches screen.</string>
     <string name="matches_placeholder_empty">There are currently no matches to display.</string>
     <string name="matches_placeholder_loading">Loading upcoming matches…</string>
+    <string name="matches_placeholder_empty_live">There are no live matches right now.</string>
+    <string name="matches_placeholder_loading_live">Loading live matches…</string>
     <string name="bottom_nav_schedule">Schedule</string>
     <string name="bottom_nav_highlights">Highlights</string>
     <string name="bottom_nav_teams">Teams</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,6 @@
     <string name="bottom_nav_placeholder_message">The %1$s screen is coming soon.</string>
     <string name="season_load_error">Unable to load seasons. Please try again.</string>
     <string name="placeholder_coming_soon">Coming soon: %1$s</string>
+    <string name="schedule_last_updated">Updated %1$s</string>
+    <string name="schedule_last_updated_placeholder">Updated --</string>
 </resources>


### PR DESCRIPTION
## Summary
- add API client, DTOs, domain models, and use case for fetching live football matches
- extract reusable team logo provider and wire new dependencies through the DI graph
- surface live match data in the schedule UI with updated placeholders and binding logic

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd65163c0c832db2f621d51841e818