### PR TITLE
Implement sign-in flow with league and team selection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.ktor.ktor.client.okhttp)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
+    implementation(libs.androidx.datastore.preferences)
     kapt(libs.androidx.room.compiler)
     debugImplementation(libs.chucker)
     testImplementation(libs.junit)

--- a/app/src/main/java/com/papa/fr/football/common/team/TeamCatalog.kt
+++ b/app/src/main/java/com/papa/fr/football/common/team/TeamCatalog.kt
@@ -1,0 +1,60 @@
+package com.papa.fr.football.common.team
+
+import androidx.annotation.DrawableRes
+import com.papa.fr.football.R
+
+data class TeamDescriptor(
+    val id: Int,
+    val leagueId: Int,
+    val name: String,
+    @DrawableRes val logoRes: Int? = null,
+)
+
+interface TeamCatalog {
+    fun teamsForLeague(leagueId: Int): List<TeamDescriptor>
+    fun findTeam(teamId: Int): TeamDescriptor?
+}
+
+class StaticTeamCatalog : TeamCatalog {
+
+    private val teamsByLeague: Map<Int, List<TeamDescriptor>> = listOf(
+        TeamDescriptor(id = 541, leagueId = 8, name = "Real Madrid"),
+        TeamDescriptor(id = 529, leagueId = 8, name = "Barcelona"),
+        TeamDescriptor(id = 530, leagueId = 8, name = "Atlético Madrid"),
+        TeamDescriptor(id = 548, leagueId = 8, name = "Real Sociedad"),
+        TeamDescriptor(id = 50, leagueId = 17, name = "Manchester City"),
+        TeamDescriptor(id = 42, leagueId = 17, name = "Arsenal"),
+        TeamDescriptor(id = 40, leagueId = 17, name = "Liverpool"),
+        TeamDescriptor(id = 38, leagueId = 17, name = "Chelsea"),
+        TeamDescriptor(id = 157, leagueId = 35, name = "Bayern München"),
+        TeamDescriptor(id = 165, leagueId = 35, name = "Borussia Dortmund"),
+        TeamDescriptor(id = 173, leagueId = 35, name = "RB Leipzig"),
+        TeamDescriptor(id = 168, leagueId = 35, name = "Bayer Leverkusen"),
+        TeamDescriptor(id = 85, leagueId = 34, name = "Paris Saint-Germain"),
+        TeamDescriptor(id = 81, leagueId = 34, name = "Olympique Marseille"),
+        TeamDescriptor(id = 80, leagueId = 34, name = "Olympique Lyonnais"),
+        TeamDescriptor(id = 91, leagueId = 34, name = "AS Monaco"),
+        TeamDescriptor(id = 113, leagueId = 23, name = "Juventus"),
+        TeamDescriptor(id = 98, leagueId = 23, name = "AC Milan"),
+        TeamDescriptor(id = 110, leagueId = 23, name = "Inter"),
+        TeamDescriptor(id = 115, leagueId = 23, name = "Napoli"),
+        TeamDescriptor(id = 194, leagueId = 37, name = "Ajax"),
+        TeamDescriptor(id = 197, leagueId = 37, name = "PSV"),
+        TeamDescriptor(id = 195, leagueId = 37, name = "Feyenoord"),
+        TeamDescriptor(id = 190, leagueId = 37, name = "AZ Alkmaar"),
+    ).groupBy { it.leagueId }.mapValues { entry ->
+        entry.value.map { team ->
+            team.copy(logoRes = team.logoRes ?: R.drawable.ic_team_placeholder)
+        }
+    }
+
+    private val teamsById: Map<Int, TeamDescriptor> = teamsByLeague.values.flatten().associateBy { it.id }
+
+    override fun teamsForLeague(leagueId: Int): List<TeamDescriptor> {
+        return teamsByLeague[leagueId].orEmpty()
+    }
+
+    override fun findTeam(teamId: Int): TeamDescriptor? {
+        return teamsById[teamId]
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/data/local/preferences/UserPreferencesDataSource.kt
+++ b/app/src/main/java/com/papa/fr/football/data/local/preferences/UserPreferencesDataSource.kt
@@ -1,0 +1,86 @@
+package com.papa.fr.football.data.local.preferences
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import com.papa.fr.football.domain.model.UserPreferences
+import java.io.IOException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+class UserPreferencesDataSource(
+    private val dataStore: DataStore<Preferences>,
+) {
+
+    val preferencesFlow: Flow<UserPreferences> = dataStore.data
+        .catch { throwable ->
+            if (throwable is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw throwable
+            }
+        }
+        .map { preferences ->
+            val favoriteTeamIds = preferences[Keys.favoriteTeamIds]
+                ?.mapNotNull { it.toIntOrNull() }
+                ?.toSet()
+                ?: emptySet()
+
+            UserPreferences(
+                isSignedIn = preferences[Keys.isSignedIn] ?: false,
+                selectedLeagueId = preferences[Keys.selectedLeagueId],
+                favoriteTeamIds = favoriteTeamIds,
+            )
+        }
+
+    suspend fun updatePreferences(
+        isSignedIn: Boolean,
+        selectedLeagueId: Int?,
+        favoriteTeamIds: Set<Int>,
+    ) {
+        dataStore.edit { preferences ->
+            preferences[Keys.isSignedIn] = isSignedIn
+            if (selectedLeagueId != null) {
+                preferences[Keys.selectedLeagueId] = selectedLeagueId
+            } else {
+                preferences.remove(Keys.selectedLeagueId)
+            }
+            if (favoriteTeamIds.isNotEmpty()) {
+                preferences[Keys.favoriteTeamIds] = favoriteTeamIds.map(Int::toString).toSet()
+            } else {
+                preferences.remove(Keys.favoriteTeamIds)
+            }
+        }
+    }
+
+    companion object {
+        private object Keys {
+            val isSignedIn = booleanPreferencesKey("is_signed_in")
+            val selectedLeagueId = intPreferencesKey("selected_league_id")
+            val favoriteTeamIds = stringSetPreferencesKey("favorite_team_ids")
+        }
+
+        fun create(
+            context: android.content.Context,
+        ): UserPreferencesDataSource {
+            val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val store = androidx.datastore.preferences.core.PreferenceDataStoreFactory.create(
+                corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+                scope = scope,
+            ) {
+                context.preferencesDataStoreFile("user_preferences")
+            }
+            return UserPreferencesDataSource(store)
+        }
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/papa/fr/football/data/repository/UserPreferencesRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.papa.fr.football.data.repository
+
+import com.papa.fr.football.data.local.preferences.UserPreferencesDataSource
+import com.papa.fr.football.domain.model.UserPreferences
+import com.papa.fr.football.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+
+class UserPreferencesRepositoryImpl(
+    private val dataSource: UserPreferencesDataSource,
+) : UserPreferencesRepository {
+
+    override val preferencesFlow: Flow<UserPreferences>
+        get() = dataSource.preferencesFlow
+
+    override suspend fun updatePreferences(
+        isSignedIn: Boolean,
+        selectedLeagueId: Int?,
+        favoriteTeamIds: Set<Int>,
+    ) {
+        dataSource.updatePreferences(isSignedIn, selectedLeagueId, favoriteTeamIds)
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/di/AppModules.kt
+++ b/app/src/main/java/com/papa/fr/football/di/AppModules.kt
@@ -5,9 +5,12 @@ import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.papa.fr.football.common.league.LeagueCatalog
 import com.papa.fr.football.common.league.StaticLeagueCatalog
+import com.papa.fr.football.common.team.StaticTeamCatalog
+import com.papa.fr.football.common.team.TeamCatalog
 import com.papa.fr.football.data.bootstrap.DataBootstrapper
 import com.papa.fr.football.data.bootstrap.MatchPrefetchQueue
 import com.papa.fr.football.data.local.database.PapaFootballDatabase
+import com.papa.fr.football.data.local.preferences.UserPreferencesDataSource
 import com.papa.fr.football.data.remote.ApiRateLimiter
 import com.papa.fr.football.data.remote.LiveEventsApiService
 import com.papa.fr.football.data.remote.RateLimitRule
@@ -17,13 +20,16 @@ import com.papa.fr.football.data.remote.TeamApiService
 import com.papa.fr.football.data.repository.MatchRepositoryImpl
 import com.papa.fr.football.data.repository.SeasonRepositoryImpl
 import com.papa.fr.football.data.repository.TeamLogoProvider
+import com.papa.fr.football.data.repository.UserPreferencesRepositoryImpl
 import com.papa.fr.football.domain.repository.MatchRepository
 import com.papa.fr.football.domain.repository.SeasonRepository
+import com.papa.fr.football.domain.repository.UserPreferencesRepository
 import com.papa.fr.football.domain.usecase.GetLiveMatchesUseCase
 import com.papa.fr.football.domain.usecase.GetRecentMatchesUseCase
 import com.papa.fr.football.domain.usecase.GetSeasonsUseCase
 import com.papa.fr.football.domain.usecase.GetUpcomingMatchesUseCase
 import com.papa.fr.football.presentation.schedule.ScheduleViewModel
+import com.papa.fr.football.presentation.signin.SignInViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.DefaultRequest
@@ -82,6 +88,7 @@ val networkModule = module {
 
 val commonModule = module {
     single<LeagueCatalog> { StaticLeagueCatalog() }
+    single<TeamCatalog> { StaticTeamCatalog() }
 }
 
 val dataModule = module {
@@ -112,6 +119,8 @@ val dataModule = module {
     single { TeamLogoProvider(get()) }
     single<SeasonRepository> { SeasonRepositoryImpl(get(), get()) }
     single<MatchRepository> { MatchRepositoryImpl(get(), get(), get(), get(), get()) }
+    single { UserPreferencesDataSource.create(androidContext()) }
+    single<UserPreferencesRepository> { UserPreferencesRepositoryImpl(get()) }
     single {
         MatchPrefetchQueue(
             matchRepository = get(),
@@ -130,4 +139,5 @@ val domainModule = module {
 
 val presentationModule = module {
     viewModel { ScheduleViewModel(get(), get(), get(), get(), get()) }
+    viewModel { SignInViewModel(get(), get(), get()) }
 }

--- a/app/src/main/java/com/papa/fr/football/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/model/UserPreferences.kt
@@ -1,0 +1,7 @@
+package com.papa.fr.football.domain.model
+
+data class UserPreferences(
+    val isSignedIn: Boolean = false,
+    val selectedLeagueId: Int? = null,
+    val favoriteTeamIds: Set<Int> = emptySet(),
+)

--- a/app/src/main/java/com/papa/fr/football/domain/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/papa/fr/football/domain/repository/UserPreferencesRepository.kt
@@ -1,0 +1,14 @@
+package com.papa.fr.football.domain.repository
+
+import com.papa.fr.football.domain.model.UserPreferences
+import kotlinx.coroutines.flow.Flow
+
+interface UserPreferencesRepository {
+    val preferencesFlow: Flow<UserPreferences>
+
+    suspend fun updatePreferences(
+        isSignedIn: Boolean,
+        selectedLeagueId: Int?,
+        favoriteTeamIds: Set<Int>,
+    )
+}

--- a/app/src/main/java/com/papa/fr/football/presentation/signin/SignInFragment.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/signin/SignInFragment.kt
@@ -6,15 +6,32 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.papa.fr.football.R
 import com.papa.fr.football.databinding.FragmentProfileBinding
 import com.papa.fr.football.presentation.MainActivity
 import com.papa.fr.football.presentation.signin.bottomsheetchoose.ChooseTeamBottomSheet
+import com.papa.fr.football.presentation.signin.adapter.FavoriteTeamsAdapter
+import com.papa.fr.football.presentation.signin.adapter.LeagueSelectionAdapter
+import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.activityViewModel
 
 class SignInFragment : Fragment() {
 
     private var _binding: FragmentProfileBinding? = null
     private val binding get() = _binding!!
+
+    private val signInViewModel: SignInViewModel by activityViewModel()
+
+    private val leagueAdapter = LeagueSelectionAdapter { league ->
+        signInViewModel.onLeagueSelected(league.id)
+        onSelectLeague(league.id)
+    }
+    private val favoriteTeamsAdapter = FavoriteTeamsAdapter()
+    private var isEditingTeams: Boolean = false
 
     private fun parentActivity() = (requireActivity() as? MainActivity)
 
@@ -29,38 +46,93 @@ class SignInFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setLayoutListener()
+        setupUi()
+        setupRecyclerViews()
+        observeState()
+        observeEvents()
     }
 
-    private fun setLayoutListener() {
+    private fun setupUi() = with(binding) {
         parentActivity()?.setBottomNavVisible(false)
 
-        with(binding) {
-            tvTitle.isVisible = true
-            groupProfile.isVisible = false
-            btnEdit.isVisible = false
+        tvTitle.isVisible = true
+        groupProfile.isVisible = false
+        btnEdit.isVisible = false
 
-            btnAddTeam.apply {
-                setOnClickListener {
-                    isVisible = !isVisible
-                    rvChooseLeague.isVisible = true
-                    groupTeamFavorite.isVisible = false
-                }
+        btnAddTeam.setOnClickListener {
+            isEditingTeams = !isEditingTeams
+            if (isEditingTeams) {
+                rvChooseLeague.isVisible = true
+                groupTeamFavorite.isVisible = false
+            } else {
+                rvChooseLeague.isVisible = false
+                groupTeamFavorite.isVisible = signInViewModel.uiState.value.favoriteTeams.isNotEmpty()
             }
-            btnSave.apply {
-                isVisible = true
-                text = getString(R.string.sign_in)
+        }
+        btnSave.apply {
+            isVisible = true
+            text = getString(R.string.sign_in)
+            setOnClickListener { signInViewModel.onSignInClicked() }
+        }
+    }
+
+    private fun setupRecyclerViews() = with(binding) {
+        rvChooseLeague.layoutManager = LinearLayoutManager(requireContext())
+        rvChooseLeague.adapter = leagueAdapter
+
+        rvFavoriteTeams.layoutManager = LinearLayoutManager(requireContext())
+        rvFavoriteTeams.adapter = favoriteTeamsAdapter
+    }
+
+    private fun observeState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                signInViewModel.uiState.collect(::renderState)
             }
         }
     }
 
+    private fun observeEvents() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                signInViewModel.events.collect { event ->
+                    when (event) {
+                        SignInEvent.TeamsConfirmed -> {
+                            isEditingTeams = false
+                            binding.rvChooseLeague.isVisible = false
+                            binding.groupTeamFavorite.isVisible = true
+                        }
+
+                        SignInEvent.NavigateToSchedule -> {
+                            isEditingTeams = false
+                            parentActivity()?.onUserSignedIn()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun renderState(state: SignInUiState) = with(binding) {
+        leagueAdapter.submitList(state.leagues)
+        favoriteTeamsAdapter.submitList(state.favoriteTeams)
+        groupTeamFavorite.isVisible = state.favoriteTeams.isNotEmpty() && !isEditingTeams
+        rvChooseLeague.isVisible = isEditingTeams
+        btnSave.isEnabled = state.favoriteTeams.isNotEmpty()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
-        parentActivity()?.setBottomNavVisible(true)
+        isEditingTeams = false
         _binding = null
     }
 
     private fun onSelectLeague(id: Int) {
-        ChooseTeamBottomSheet().show(parentFragmentManager, "ChooseTeamBottomSheet")
+        ChooseTeamBottomSheet.newInstance(id)
+            .show(childFragmentManager, ChooseTeamBottomSheet.TAG)
+    }
+
+    companion object {
+        const val TAG = "SignInFragment"
     }
 }

--- a/app/src/main/java/com/papa/fr/football/presentation/signin/SignInViewModel.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/signin/SignInViewModel.kt
@@ -1,0 +1,161 @@
+package com.papa.fr.football.presentation.signin
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.papa.fr.football.common.league.LeagueCatalog
+import com.papa.fr.football.common.league.LeagueDescriptor
+import com.papa.fr.football.common.team.TeamCatalog
+import com.papa.fr.football.common.team.TeamDescriptor
+import com.papa.fr.football.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+
+class SignInViewModel(
+    private val leagueCatalog: LeagueCatalog,
+    private val teamCatalog: TeamCatalog,
+    private val userPreferencesRepository: UserPreferencesRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        SignInUiState(
+            leagues = leagueCatalog.leagues.map { it.toUiModel() },
+        )
+    )
+    val uiState: StateFlow<SignInUiState> = _uiState
+
+    private val _events = MutableSharedFlow<SignInEvent>()
+    val events: SharedFlow<SignInEvent> = _events
+
+    private var selectedTeamIds: MutableSet<Int> = mutableSetOf()
+    private var pendingTeamIds: MutableSet<Int> = mutableSetOf()
+
+    init {
+        viewModelScope.launch {
+            userPreferencesRepository.preferencesFlow.collect { preferences ->
+                selectedTeamIds = preferences.favoriteTeamIds.toMutableSet()
+                if (pendingTeamIds.isEmpty()) {
+                    pendingTeamIds = selectedTeamIds.toMutableSet()
+                }
+                val favoriteTeams = resolveFavoriteTeams(selectedTeamIds)
+                _uiState.value = _uiState.value.copy(
+                    selectedLeagueId = preferences.selectedLeagueId,
+                    favoriteTeams = favoriteTeams,
+                    isSignedIn = preferences.isSignedIn,
+                )
+            }
+        }
+    }
+
+    fun onLeagueSelected(leagueId: Int) {
+        pendingTeamIds = selectedTeamIds.toMutableSet()
+        updateAvailableTeams(leagueId)
+        _uiState.value = _uiState.value.copy(selectedLeagueId = leagueId)
+    }
+
+    fun onTeamSelectionChanged(teamId: Int, isSelected: Boolean) {
+        if (isSelected) {
+            pendingTeamIds.add(teamId)
+        } else {
+            pendingTeamIds.remove(teamId)
+        }
+        val leagueId = _uiState.value.selectedLeagueId ?: return
+        updateAvailableTeams(leagueId)
+    }
+
+    fun confirmTeamSelection() {
+        selectedTeamIds = pendingTeamIds.toMutableSet()
+        val favoriteTeams = resolveFavoriteTeams(selectedTeamIds)
+        _uiState.value = _uiState.value.copy(
+            favoriteTeams = favoriteTeams,
+        )
+        viewModelScope.launch {
+            _events.emit(SignInEvent.TeamsConfirmed)
+        }
+    }
+
+    fun onSignInClicked() {
+        val state = _uiState.value
+        viewModelScope.launch {
+            userPreferencesRepository.updatePreferences(
+                isSignedIn = true,
+                selectedLeagueId = state.selectedLeagueId,
+                favoriteTeamIds = selectedTeamIds,
+            )
+            _events.emit(SignInEvent.NavigateToSchedule)
+        }
+    }
+
+    private fun updateAvailableTeams(leagueId: Int) {
+        val teams = teamCatalog.teamsForLeague(leagueId)
+        val availableTeams = teams.map { it.toSelectionUiModel(pendingTeamIds.contains(it.id)) }
+        _uiState.value = _uiState.value.copy(
+            availableTeams = availableTeams,
+        )
+    }
+
+    private fun resolveFavoriteTeams(teamIds: Set<Int>): List<FavoriteTeamUiModel> {
+        return teamIds.mapNotNull(teamCatalog::findTeam)
+            .sortedBy { it.name }
+            .map { descriptor -> descriptor.toFavoriteUiModel() }
+    }
+
+    private fun LeagueDescriptor.toUiModel(): LeagueUiModel {
+        return LeagueUiModel(
+            id = id,
+            name = name,
+            iconRes = iconRes,
+        )
+    }
+
+    private fun TeamDescriptor.toSelectionUiModel(isSelected: Boolean): TeamSelectionUiModel {
+        return TeamSelectionUiModel(
+            id = id,
+            name = name,
+            logoRes = logoRes,
+            isSelected = isSelected,
+        )
+    }
+
+    private fun TeamDescriptor.toFavoriteUiModel(): FavoriteTeamUiModel {
+        return FavoriteTeamUiModel(
+            id = id,
+            name = name,
+            logoRes = logoRes,
+        )
+    }
+}
+
+sealed interface SignInEvent {
+    data object TeamsConfirmed : SignInEvent
+    data object NavigateToSchedule : SignInEvent
+}
+
+data class SignInUiState(
+    val leagues: List<LeagueUiModel> = emptyList(),
+    val selectedLeagueId: Int? = null,
+    val availableTeams: List<TeamSelectionUiModel> = emptyList(),
+    val favoriteTeams: List<FavoriteTeamUiModel> = emptyList(),
+    val isSignedIn: Boolean = false,
+)
+
+data class LeagueUiModel(
+    val id: Int,
+    val name: String,
+    val iconRes: Int?,
+)
+
+data class TeamSelectionUiModel(
+    val id: Int,
+    val name: String,
+    val logoRes: Int?,
+    val isSelected: Boolean,
+)
+
+data class FavoriteTeamUiModel(
+    val id: Int,
+    val name: String,
+    val logoRes: Int?,
+)

--- a/app/src/main/java/com/papa/fr/football/presentation/signin/adapter/FavoriteTeamsAdapter.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/signin/adapter/FavoriteTeamsAdapter.kt
@@ -1,0 +1,58 @@
+package com.papa.fr.football.presentation.signin.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.papa.fr.football.databinding.ItemTeamBinding
+import com.papa.fr.football.presentation.signin.FavoriteTeamUiModel
+
+class FavoriteTeamsAdapter :
+    ListAdapter<FavoriteTeamUiModel, FavoriteTeamsAdapter.FavoriteTeamViewHolder>(DIFF_CALLBACK) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FavoriteTeamViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemTeamBinding.inflate(inflater, parent, false)
+        return FavoriteTeamViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: FavoriteTeamViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class FavoriteTeamViewHolder(
+        private val binding: ItemTeamBinding,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: FavoriteTeamUiModel) {
+            binding.tvTeamName.text = item.name
+            if (item.logoRes != null) {
+                binding.ivLogo.setImageResource(item.logoRes)
+            } else {
+                binding.ivLogo.setImageDrawable(null)
+            }
+            binding.ivIndicatorActive.isVisible = true
+            binding.groupEdit.isVisible = false
+        }
+    }
+
+    private companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<FavoriteTeamUiModel>() {
+            override fun areItemsTheSame(
+                oldItem: FavoriteTeamUiModel,
+                newItem: FavoriteTeamUiModel,
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: FavoriteTeamUiModel,
+                newItem: FavoriteTeamUiModel,
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/presentation/signin/adapter/LeagueSelectionAdapter.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/signin/adapter/LeagueSelectionAdapter.kt
@@ -1,0 +1,48 @@
+package com.papa.fr.football.presentation.signin.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.papa.fr.football.databinding.ItemLeagueAddTeamsBinding
+import com.papa.fr.football.presentation.signin.LeagueUiModel
+
+class LeagueSelectionAdapter(
+    private val onLeagueSelected: (LeagueUiModel) -> Unit,
+) : ListAdapter<LeagueUiModel, LeagueSelectionAdapter.LeagueViewHolder>(DIFF_CALLBACK) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LeagueViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemLeagueAddTeamsBinding.inflate(inflater, parent, false)
+        return LeagueViewHolder(binding, onLeagueSelected)
+    }
+
+    override fun onBindViewHolder(holder: LeagueViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class LeagueViewHolder(
+        private val binding: ItemLeagueAddTeamsBinding,
+        private val onLeagueSelected: (LeagueUiModel) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: LeagueUiModel) {
+            binding.itlLeague.setTitle(item.name)
+            item.iconRes?.let(binding.itlLeague::setLogo)
+            binding.root.setOnClickListener { onLeagueSelected(item) }
+        }
+    }
+
+    private companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<LeagueUiModel>() {
+            override fun areItemsTheSame(oldItem: LeagueUiModel, newItem: LeagueUiModel): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(oldItem: LeagueUiModel, newItem: LeagueUiModel): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/papa/fr/football/presentation/signin/adapter/TeamSelectionAdapter.kt
+++ b/app/src/main/java/com/papa/fr/football/presentation/signin/adapter/TeamSelectionAdapter.kt
@@ -1,0 +1,68 @@
+package com.papa.fr.football.presentation.signin.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.papa.fr.football.databinding.ItemFavoriteTeamBinding
+import com.papa.fr.football.presentation.signin.TeamSelectionUiModel
+
+class TeamSelectionAdapter(
+    private val onSelectionChanged: (teamId: Int, isSelected: Boolean) -> Unit,
+) : ListAdapter<TeamSelectionUiModel, TeamSelectionAdapter.TeamSelectionViewHolder>(DIFF_CALLBACK) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TeamSelectionViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemFavoriteTeamBinding.inflate(inflater, parent, false)
+        return TeamSelectionViewHolder(binding, onSelectionChanged)
+    }
+
+    override fun onBindViewHolder(holder: TeamSelectionViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class TeamSelectionViewHolder(
+        private val binding: ItemFavoriteTeamBinding,
+        private val onSelectionChanged: (teamId: Int, isSelected: Boolean) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: TeamSelectionUiModel) {
+            binding.tvTeamName.text = item.name
+            if (item.logoRes != null) {
+                binding.ivLogo.setImageResource(item.logoRes)
+            } else {
+                binding.ivLogo.setImageDrawable(null)
+            }
+            binding.cbTeam.setOnCheckedChangeListener(null)
+            binding.cbTeam.isChecked = item.isSelected
+            binding.cbTeam.setOnCheckedChangeListener { _, isChecked ->
+                onSelectionChanged(item.id, isChecked)
+            }
+            binding.cbTeam.isVisible = true
+            binding.root.setOnClickListener {
+                val newState = !binding.cbTeam.isChecked
+                binding.cbTeam.isChecked = newState
+            }
+        }
+    }
+
+    private companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<TeamSelectionUiModel>() {
+            override fun areItemsTheSame(
+                oldItem: TeamSelectionUiModel,
+                newItem: TeamSelectionUiModel,
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: TeamSelectionUiModel,
+                newItem: TeamSelectionUiModel,
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_team_placeholder.xml
+++ b/app/src/main/res/drawable/ic_team_placeholder.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#3D5AFE"
+        android:pathData="M12,2A10,10 0 1,0 22,12 10,10 0 0,0 12,2ZM12,6a3,3 0 1,1 -3,3A3,3 0 0,1 12,6ZM12,20.2a7.69,7.69 0 0,1 -6-2.94c0.06-1.99 4-3.08 6-3.08s5.94,1.09 6,3.08A7.69,7.69 0 0,1 12,20.2Z" />
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ koin = "3.5.6"
 coroutines = "1.9.0"
 lifecycleViewModel = "2.8.6"
 room = "2.6.1"
+datastore = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -45,6 +46,7 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add a static team catalog and placeholder asset to drive league-specific team options
- introduce a DataStore-backed user preference repository and wire it through Koin for persisting sign-in state and favorites
- implement a dedicated SignInViewModel, adapters, and updated fragment/bottom sheet flows to handle league/team selection and toggle navigation visibility
- update MainActivity to show the sign-in experience for first-time users and add the DataStore dependency

## Testing
- ⚠️ `./gradlew lint --console=plain` *(command hung and the Gradle daemon exited unexpectedly in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce90b62fac832da47f20514ef1afc1